### PR TITLE
chore: added random move baseline [DO NOT MERGE]

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -22,7 +22,7 @@ use uci_parser::{UciCommand, UciOption, UciParseError, UciResponse};
 use crate::{EngineCommand, Evaluator, Search, SearchConfig, SearchResult, BENCHMARK_FENS};
 
 /// Default depth at which to run the benchmark searches.
-const BENCH_DEPTH: usize = 5;
+const BENCH_DEPTH: usize = 4;
 
 /// The Toad chess engine.
 #[derive(Debug)]

--- a/src/search.rs
+++ b/src/search.rs
@@ -183,6 +183,9 @@ impl<'a> Search<'a> {
 
         // let res = self.iterative_deepening();
         let res = self.random_move();
+        // Mimic a "costly" search
+        let mimic = self.config.soft_timeout.min(Duration::from_millis(8));
+        std::thread::sleep(mimic);
 
         // Search has ended; send bestmove
         let response = UciResponse::BestMove {

--- a/src/search.rs
+++ b/src/search.rs
@@ -182,10 +182,11 @@ impl<'a> Search<'a> {
         // );
 
         // let res = self.iterative_deepening();
-        let res = self.random_move();
+        let mut res = self.random_move();
         // Mimic a "costly" search
         let mimic = self.config.soft_timeout.min(Duration::from_millis(8));
         std::thread::sleep(mimic);
+        res.nodes += 13705658 / 128; // Benchmark of `main` divided by number of positions, to give a rough estimate of NPS
 
         // Search has ended; send bestmove
         let response = UciResponse::BestMove {
@@ -339,7 +340,6 @@ impl<'a> Search<'a> {
     fn random_move(&mut self) -> SearchResult {
         let mut res = self.result;
         let moves = self.game.get_legal_moves();
-        res.nodes += 1;
 
         // If there are any legal moves available, pick a random one.
         if moves.is_empty() {

--- a/src/search.rs
+++ b/src/search.rs
@@ -181,8 +181,8 @@ impl<'a> Search<'a> {
         //     self.config.hard_timeout.as_millis()
         // );
 
-        let res = self.iterative_deepening();
-        // let res = self.random_move();
+        // let res = self.iterative_deepening();
+        let res = self.random_move();
 
         // Search has ended; send bestmove
         let response = UciResponse::BestMove {
@@ -206,7 +206,7 @@ impl<'a> Search<'a> {
     /// However, with features such as move ordering, a/b pruning, and aspiration windows, ID enhances performance.
     ///
     /// After each iteration, we check if we've exceeded our `soft_timeout` and, if we haven't, we run a search at a greater depth.
-    fn iterative_deepening(&mut self) -> SearchResult {
+    fn _iterative_deepening(&mut self) -> SearchResult {
         // Start at depth 1 because a search at depth 0 makes no sense
         let mut depth = 1;
 
@@ -225,7 +225,7 @@ impl<'a> Search<'a> {
             self.result.score = -Score::INF;
 
             // If the search returned an error, it was cancelled, so exit the iterative deepening loop.
-            if let Err(e) = self.negamax(*self.game, depth, 0) {
+            if let Err(e) = self._negamax(*self.game, depth, 0) {
                 self.send_info(UciInfo::new().string(format!(
                     "Search cancelled during depth {depth} while evaluating {} with score {}: {e}",
                     self.result.bestmove.unwrap_or_default(),
@@ -274,7 +274,7 @@ impl<'a> Search<'a> {
     /// Primary location of search logic.
     ///
     /// Uses the [negamax](https://www.chessprogramming.org/Negamax) algorithm.
-    fn negamax(&mut self, game: Game, depth: usize, ply: i32) -> Result<Score> {
+    fn _negamax(&mut self, game: Game, depth: usize, ply: i32) -> Result<Score> {
         self.result.nodes += 1;
         // If we've reached a terminal node, evaluate the position
         if depth == 0 {
@@ -320,7 +320,7 @@ impl<'a> Search<'a> {
             let new_game = game.with_move_made(mv);
 
             // Recurse
-            let new_score = -self.negamax(new_game, depth - 1, ply + 1)?;
+            let new_score = -self._negamax(new_game, depth - 1, ply + 1)?;
 
             // If the new score is better than the current score, update it.
             score = score.max(new_score);
@@ -332,11 +332,11 @@ impl<'a> Search<'a> {
         Ok(score)
     }
 
-    /*
     /// Chooses a random legal move to play.
     fn random_move(&mut self) -> SearchResult {
         let mut res = self.result;
         let moves = self.game.get_legal_moves();
+        res.nodes += 1;
 
         // If there are any legal moves available, pick a random one.
         if moves.is_empty() {
@@ -399,7 +399,6 @@ impl<'a> Search<'a> {
 
         res
     }
-     */
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR is *not* intended to be merged, rather it is intended to serve as a record of the baseline of the engine's performance.

At the time of writing, `main` has the following minimal features for search/eval:
- Iterative deppening, for time management (no aspiration windows or move ordering)
- Pure negamax, for search (no pruning or move ordering)
- Material difference evaluation

So, `main`, at this time, is a "baseline" for our engine.

To compare, and to ensure that things were working as expected, I created this branch and replaced the search code with a random mover. That is, it selects a random legal move, if possible, to play at every position. It searches at a depth of 1 every time, and mimics a "costly" search by sleeping for a short duration. The code to generate a random move is ugly, but it didn't need to be pretty- it just needed to work. There is also some code that adds an arbitrarily-large number to the "nodes searched" field when picking a random move. This, coupled with the "costly" search mimicking, was to force the NPS metric in the benchmark to be close in magnitude to `main`'s benchmark. OpenBench was providing arbitrarily-large time controls when the two version's NPS were not similar.

Moving forward, all development will be done on a `dev` branch, and `main` should always contain the latest version of Toad, fully-functional and stronger than previous versions.

To sign off, here are the results from the SPRT of `main` vs `random-move`:
```
Elo   | 1199.83 +- 0.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.66 (-2.94, 2.94) [0.00, 3.00]
Games | N: 274 W: 274 L: 0 D: 0
Penta | [0, 0, 0, 0, 137]
```
(SPRT was ended early, because `274-0` is enough to confidently say that `main` is better than random...)