### PR TITLE
feat: added MVV-LVA move ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Toad uses several state-of-the-art techniques in [chess programming](https://www
 -   Search:
     -   Based on the [Negamax](https://www.chessprogramming.org/Negamax) algorithm.
     -   [Alpha-Beta Pruning](https://www.chessprogramming.org/Alpha-Beta#Negamax_Framework) in a fail soft framework.
+    -   Move Ordering:
+        -   [MVV-LVA](https://www.chessprogramming.org/MVV-LVA)
 -   Evaluation:
     -   [Material difference](https://www.chessprogramming.org/Material)
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -72,7 +72,7 @@ pub const fn value_of(kind: PieceKind) -> i32 {
         PieceKind::Bishop => 330,
         PieceKind::Rook => 500,
         PieceKind::Queen => 900,
-        PieceKind::King => 20_000,
+        PieceKind::King => 10,
     }
 }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -72,7 +72,7 @@ pub const fn value_of(kind: PieceKind) -> i32 {
         PieceKind::Bishop => 330,
         PieceKind::Rook => 500,
         PieceKind::Queen => 900,
-        PieceKind::King => 10,
+        PieceKind::King => 20_000,
     }
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -475,7 +475,7 @@ fn score_move(game: &Game, mv: &Move) -> Score {
 /// C   B| 670   2870  2970  4670  8670  0     
 /// K   R| 500   2700  2800  4500  8500  0     
 /// E   Q| 100   2300  2400  4100  8100  0     
-/// R   K| 990   3190  3290  4990  8990  0     
+/// R   K| 1000  3200  3300  5000  9000  0     
 /// ```
 const MVV_LVA: [[i32; PieceKind::COUNT]; PieceKind::COUNT] = {
     let mut matrix = [[0; PieceKind::COUNT]; PieceKind::COUNT];
@@ -494,9 +494,9 @@ const MVV_LVA: [[i32; PieceKind::COUNT]; PieceKind::COUNT] = {
             // bench: 27609398 nodes 5716479 nps
             // let score = (victim * 10 + (count - attacker)) as i32;
 
-            // Default MVV-LVA; With value_of(King) := 10, this orders Kx<piece> before Px<piece>
-            // bench: 27032804 nodes 5443765 nps
-            let score = 10 * value_of(vtm) - value_of(atk);
+            // Default MVV-LVA; Assigns negative values for King attacks
+            // bench: 30937536 nodes 5867022 nps
+            // let score = 10 * value_of(vtm) - value_of(atk);
 
             // If the attacker is the King, the score is half the victim's value.
             // This encourages the King to attack, but not as strongly as other pieces.
@@ -508,6 +508,15 @@ const MVV_LVA: [[i32; PieceKind::COUNT]; PieceKind::COUNT] = {
             //     10 * value_of(vtm) - value_of(atk)
             // };
 
+            // Default MVV-LVA except that the King is assigned a value of 0 if he is attacking
+            // bench: 27032804 nodes 8136592 nps
+            let score = if attacker == count - 1 {
+                10 * value_of(vtm)
+            } else {
+                // Standard MVV-LVA computation
+                10 * value_of(vtm) - value_of(atk)
+            };
+
             matrix[attacker][victim] = score;
             victim += 1;
         }
@@ -518,7 +527,7 @@ const MVV_LVA: [[i32; PieceKind::COUNT]; PieceKind::COUNT] = {
 
 /// Utility function to print the MVV-LVA table
 #[allow(dead_code)]
-fn print_mvv_lva_table() {
+pub fn print_mvv_lva_table() {
     print!("\nX   ");
     for victim in PieceKind::iter() {
         let v = victim.char().to_ascii_uppercase();

--- a/src/search.rs
+++ b/src/search.rs
@@ -496,17 +496,17 @@ const MVV_LVA: [[i32; PieceKind::COUNT]; PieceKind::COUNT] = {
 
             // Default MVV-LVA; Assigns negative values for King attacks
             // bench: 30937536 nodes 5867022 nps
-            // let score = 10 * value_of(vtm) - value_of(atk);
+            let score = 10 * value_of(vtm) - value_of(atk);
 
             // If the attacker is the King, the score is half the victim's value.
             // This encourages the King to attack, but not as strongly as other pieces.
             // bench: 27107011 nodes 5647285 nps
-            let score = if attacker == count - 1 {
-                value_of(vtm) / 2
-            } else {
-                // Standard MVV-LVA computation
-                10 * value_of(vtm) - value_of(atk)
-            };
+            // let score = if attacker == count - 1 {
+            //     value_of(vtm) / 2
+            // } else {
+            //     // Standard MVV-LVA computation
+            //     10 * value_of(vtm) - value_of(atk)
+            // };
 
             matrix[attacker][victim] = score;
             victim += 1;

--- a/src/search.rs
+++ b/src/search.rs
@@ -475,7 +475,7 @@ fn score_move(game: &Game, mv: &Move) -> Score {
 /// C   B| 670   2870  2970  4670  8670  0     
 /// K   R| 500   2700  2800  4500  8500  0     
 /// E   Q| 100   2300  2400  4100  8100  0     
-/// R   K| 50    160   165   250   450   0     
+/// R   K| 990   3190  3290  4990  8990  0     
 /// ```
 const MVV_LVA: [[i32; PieceKind::COUNT]; PieceKind::COUNT] = {
     let mut matrix = [[0; PieceKind::COUNT]; PieceKind::COUNT];
@@ -494,8 +494,8 @@ const MVV_LVA: [[i32; PieceKind::COUNT]; PieceKind::COUNT] = {
             // bench: 27609398 nodes 5716479 nps
             // let score = (victim * 10 + (count - attacker)) as i32;
 
-            // Default MVV-LVA; Assigns negative values for King attacks
-            // bench: 30937536 nodes 5867022 nps
+            // Default MVV-LVA; With value_of(King) := 10, this orders Kx<piece> before Px<piece>
+            // bench: 27032804 nodes 5443765 nps
             let score = 10 * value_of(vtm) - value_of(atk);
 
             // If the attacker is the King, the score is half the victim's value.


### PR DESCRIPTION
resolves #9 

---

Implements [MVV-LVA](https://www.chessprogramming.org/MVV-LVA) move ordering to be used in the search.

The current implementation of "move ordering" is using the [`Slice::sort_by_cached_key`](https://doc.rust-lang.org/std/primitive.slice.html#method.sort_by_cached_key) method and calling a `score_move` function. Right now, this function *only* scores moves by a MVV-LVA calculation. Further move ordering techniques (promotions, safe squares, etc.) will be considered later.

There were two major design decisions made during this PR:
A. Sorting the entire list with a built-in sort function
B. How MVV-LVA scores are calculated

Regarding A:
I initially read Rustic's [page on move ordering](https://rustic-chess.org/search/ordering/how.html) and wanted to implement that method. Rustic's method is to score all moves, and then iterate over the move list one-by-one, getting the "next best" move at each iteration. The idea behind this approach is that, due to a/b pruning, we're not likely to *need* to look at every move in the list, so why bother sorting the *whole list*? I attempted to implement this approach, but it was horrendously slow compared to just using `sort_by_cached_key`. From further investigation, it seems Rustic stores move scores in the move itself, so that may warrant more tests later down the line. For now, though, the built-in sort function works fine. [See this comment for more](https://github.com/dannyhammer/toad/issues/9#issuecomment-2401208370).

Regarding B:
I tested three ways of computing the MVV-LVA score:
1. Using Rustic's [MVV-LVA table](https://rustic-chess.org/search/ordering/mvv_lva.html) wherein the "scores" are just arbitrary, monotonically-increasing values.
2. Using a "basic" MVV-LVA computation of `10 * value(victim) - value(attacker)`.
3. Using an altered version of 2 where, if the King was the attacker, the score was `value(victim) / 2`.
4. Using an altered version of 2 where we set `value_of(King) < value_of(Pawn)`.

In testing, I found that approach 4 worked the best. My intuition is that, with 2 providing negative scores for moves where the King captures an enemy piece, that would put potentially good captures very low in the move list, thus making us have to examine more positions. For 1, I wasn't sure exactly *why* it behaved worse, just that it did. Initially, 3 seemed like the best option, but it was pointed out to me in the CP discord that ordering captures with the King first might be a good idea, so I tried that. It's worth noting that this might not be great once more advanced features like SEE are implemented. But, it's the highest gainer now, so we're rolling with it.

Here are the SPRT results for comparing these methods:

Method 3 vs `main`:
```
Elo   | 227.40 +- 28.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 656 W: 458 L: 81 D: 117
Penta | [4, 14, 70, 81, 159]
```

Rustic's method vs method 3:
```
Elo   | 0.93 +- 4.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.04 (-2.94, 2.94) [0.00, 3.00]
Games | N: 5620 W: 2016 L: 2001 D: 1603
Penta | [121, 282, 2003, 269, 135]
https://pyronomy.pythonanywhere.com/test/2/
```

Negative-King-Captures vs method 3:
```
Elo   | -23.42 +- 8.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.59 (-2.94, 2.94) [0.00, 3.00]
Games | N: 2630 W: 886 L: 1063 D: 681
Penta | [99, 229, 789, 146, 52]
https://pyronomy.pythonanywhere.com/test/3/
```

Method 4 vs method 3
```
Elo   | 15.43 +- 5.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=1MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 5116 W: 2014 L: 1787 D: 1315
Penta | [127, 308, 1522, 413, 188]
https://pyronomy.pythonanywhere.com/test/4/
```

* I decided to cancel these tests early due to time constraints & needing the compute power for another task. I know these results aren't conclusive, but they're good enough for now, and I may look at alternate MVV-LVA calculations later.

At any rate, approach 3 produces the following score table:
```
                    VICTIM
A       P     N     B     R     Q     K     
T    +---------------------------------+
T   P| 900   3100  3200  4900  8900  0     
A   N| 680   2880  2980  4680  8680  0     
C   B| 670   2870  2970  4670  8670  0     
K   R| 500   2700  2800  4500  8500  0     
E   Q| 100   2300  2400  4100  8100  0     
R   K| 50    160   165   250   450   0     
```

As you can see, moves where the King captures pieces are still given positive values that "make sense." i.e. we should examine a move where a King captures a Knight before we examine a move where a Pawn captures a Pawn, but not before we examine a Pawn capturing a Knight.

--- 
SPRT:
```
Elo   | 142.98 +- 29.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.07 (-2.94, 2.94) [0.00, 10.00]
Games | N: 254 W: 117 L: 18 D: 119
Penta | [1, 7, 32, 66, 21]
https://pyronomy.pythonanywhere.com/test/5/
```

bench: 27107011