### PR TITLE
feat: added quiescence search

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -289,8 +289,7 @@ impl<'a> Search<'a> {
 
         // If we've reached a terminal node, evaluate the current position
         if depth == 0 {
-            // return self.quiescence_search(game, ply, alpha, beta);
-            return Ok((None, Evaluator::new(&game).eval()));
+            return self.quiescence_search(game, ply, alpha, beta);
         }
 
         // If there are no legal moves, it's either mate or a draw.
@@ -344,7 +343,6 @@ impl<'a> Search<'a> {
         Ok((bestmove, best))
     }
 
-    /*
     /// Quiescence Search (QSearch)
     ///
     /// A search that looks at only possible captures and capture-chains.
@@ -386,7 +384,7 @@ impl<'a> Search<'a> {
         captures.sort_by_cached_key(|mv| score_move(&game, mv));
 
         let mut best = stand_pat;
-        let mut bestmove = captures.first().copied(); // Safe because we guaranteed `moves` to be nonempty above
+        let mut bestmove = captures.first().copied();
 
         for mv in captures {
             // Check if we can continue searching
@@ -418,7 +416,6 @@ impl<'a> Search<'a> {
 
         Ok((bestmove, best)) // fail-soft
     }
-     */
 
     /// Checks if we've exceeded any conditions that would warrant the search to end.
     ///


### PR DESCRIPTION
resolves #8 

Much of this was already written when #22 was merged, because I was originally intending to do QSearch before MVV-LVA. However, when I ran benchmarks with QSearch before MVV-LVA, results were not great, so I switched the priority of those two.

Anyway, QSearch is now implemented using a fail soft framework, just like in Negamax. There is potentially room for speedup in `chessie` for generating captures only. Right now I am generating all legal moves and filtering out non-captures. It would be nice to generate *only* captures. However, that would require a special edge case whenever an en passant capture is available, so I'll just make an issue in `chessie` and leave this be for now.

SPRT:
---
```
Elo   | 100.50 +- 28.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 10.00]
Games | N: 302 W: 114 L: 29 D: 159
Penta | [2, 16, 52, 57, 24]
https://pyronomy.pythonanywhere.com/test/6/
```

bench: 30010755