### PR TITLE
feat: implemented draw detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,9 +65,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "chessie"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bea3c02c1976b97038e706a65eef3a71d06ed07919bd3031ca734ec5f32993"
+checksum = "5209620a11ee21ab147a0620e42bf1e7c44e7789713bd99d00acd726b214d293"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "chessie_types"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6731cf823004d7759ab9da16f11da5d21ef7e19d1b8d2ed219cb0d01d4f9ea"
+checksum = "66f0a899bb7b1deafb23d010af51421188997d498e7577b5d98daf00118dead2"
 dependencies = [
  "anyhow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["chess", "chess engine"]
 
 [dependencies]
 anyhow = "1.0.89"
-chessie = "1.1.0"
+chessie = "1.2.0"
 #chessie = { path = "../chessie/chessie" }
 #chessie = { git = "https://github.com/dannyhammer/chessie.git" }
 clap = { version = "4.5.18", features = ["derive"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,6 +47,11 @@ pub enum EngineCommand {
     /// Flips the side-to-move. Equivalent to playing a nullmove.
     Flip,
 
+    /// Apply the provided move to the game, if possible.
+    ///
+    /// No enforcement of legality, so you can move a White piece twice in a row, if you want.
+    MakeMove { mv_string: String },
+
     /// Shows all legal moves in the current position.
     ///
     /// If `square` is provided, it will display all available moves from that square.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -330,7 +330,7 @@ impl Engine {
         // Spawn a thread to conduct the search
         let handle = thread::spawn(move || {
             // Launch the search, performing iterative deepening, negamax, a/b pruning, etc.
-            Search::new(&game, is_searching.clone(), config).start()
+            Search::new(is_searching.clone(), config).start(&game)
         });
 
         Some(handle)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -15,7 +15,7 @@ use std::{
 };
 
 use anyhow::{bail, Context, Result};
-use chessie::{print_perft, Game, Move};
+use chessie::{print_perft, Game, Move, Position};
 use clap::Parser;
 use uci_parser::{UciCommand, UciOption, UciParseError, UciResponse};
 
@@ -32,6 +32,11 @@ pub struct Engine {
     /// This is modified whenever moves are played or new positions are given,
     /// and is reset whenever the engine is told to start a new game.
     game: Game,
+
+    /// All previous positions of `self.game`, including the current position.
+    ///
+    /// Updated when the engine makes a move or receives `position ... moves [move list]`.
+    history: Vec<Position>,
 
     /// One half of a channel, responsible for sending commands to the engine to execute.
     sender: Sender<EngineCommand>,
@@ -52,8 +57,13 @@ impl Engine {
         // Construct a channel for communication and threadpool for parallel tasks
         let (sender, receiver) = channel();
 
+        let game = Game::default();
+        let mut history = Vec::with_capacity(512);
+        history.push(*game.position());
+
         Self {
-            game: Game::default(),
+            game,
+            history,
             sender,
             receiver,
             is_searching: Arc::default(),
@@ -104,6 +114,13 @@ impl Engine {
                 EngineCommand::Fen => println!("{}", self.game.to_fen()),
 
                 EngineCommand::Flip => self.game.toggle_side_to_move(),
+
+                EngineCommand::MakeMove { mv_string } => {
+                    match Move::from_uci(&self.game, &mv_string) {
+                        Ok(mv) => self.make_move(mv),
+                        Err(e) => eprintln!("{e}"),
+                    }
+                }
 
                 EngineCommand::Moves { square } => {
                     // Get the legal moves
@@ -289,10 +306,16 @@ impl Engine {
         // Apply the provided moves
         for mv_str in moves {
             let mv = Move::from_uci(&self.game, mv_str.as_ref())?;
-            self.game.make_move(mv);
+            self.make_move(mv);
         }
 
         Ok(())
+    }
+
+    // Makes the supplied move on the current position.
+    fn make_move(&mut self, mv: Move) {
+        self.game.make_move(mv);
+        self.history.push(*self.game.position());
     }
 
     /// Resets the engine's internal game state.
@@ -326,11 +349,14 @@ impl Engine {
         // Clone the parameters that will be sent into the thread
         let game = self.game;
         let is_searching = Arc::clone(&self.is_searching);
+        let mut history = self.history.clone();
+        // Cloning a vec doesn't clone its capacity
+        history.reserve(self.history.capacity());
 
         // Spawn a thread to conduct the search
         let handle = thread::spawn(move || {
             // Launch the search, performing iterative deepening, negamax, a/b pruning, etc.
-            Search::new(is_searching.clone(), config).start(&game)
+            Search::new(is_searching.clone(), config, history).start(&game)
         });
 
         Some(handle)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -349,14 +349,15 @@ impl Engine {
         // Clone the parameters that will be sent into the thread
         let game = self.game;
         let is_searching = Arc::clone(&self.is_searching);
-        let mut history = self.history.clone();
+        // let mut history = self.history.clone();
         // Cloning a vec doesn't clone its capacity
-        history.reserve(self.history.capacity());
+        // history.reserve(self.history.capacity());
 
         // Spawn a thread to conduct the search
         let handle = thread::spawn(move || {
             // Launch the search, performing iterative deepening, negamax, a/b pruning, etc.
-            Search::new(is_searching.clone(), config, history).start(&game)
+            // Search::new(is_searching.clone(), config, history).start(&game)
+            Search::new(is_searching.clone(), config).start(&game)
         });
 
         Some(handle)

--- a/src/search.rs
+++ b/src/search.rs
@@ -310,7 +310,7 @@ impl Search {
             let new_game = game.with_move_made(mv);
 
             // Determine the score of making this move
-            let score = if game.can_draw_by_fifty() {
+            let score = if new_game.can_draw_by_fifty() {
                 Score::DRAW
             } else {
                 -self
@@ -389,7 +389,7 @@ impl Search {
             let new_game = game.with_move_made(mv);
 
             // Determine the score of making this move
-            let score = if game.can_draw_by_fifty() {
+            let score = if new_game.can_draw_by_fifty() {
                 Score::DRAW
             } else {
                 -self

--- a/src/search.rs
+++ b/src/search.rs
@@ -310,9 +310,13 @@ impl Search {
             let new_game = game.with_move_made(mv);
 
             // Determine the score of making this move
-            let score = -self
-                .negamax(&new_game, depth - 1, ply + 1, -beta, -alpha)?
-                .1;
+            let score = if game.can_draw_by_fifty() {
+                Score::DRAW
+            } else {
+                -self
+                    .negamax(&new_game, depth - 1, ply + 1, -beta, -alpha)?
+                    .1
+            };
 
             // If we've found a better move than our current best, update the results
             if score > best {
@@ -385,9 +389,13 @@ impl Search {
             let new_game = game.with_move_made(mv);
 
             // Determine the score of making this move
-            let score = -self
-                .quiescence_search(&new_game, _ply + 1, -beta, -alpha)?
-                .1;
+            let score = if game.can_draw_by_fifty() {
+                Score::DRAW
+            } else {
+                -self
+                    .quiescence_search(&new_game, _ply + 1, -beta, -alpha)?
+                    .1
+            };
 
             // If we've found a better move than our current best, update our result
             if score > best {

--- a/src/search.rs
+++ b/src/search.rs
@@ -129,14 +129,9 @@ impl Default for SearchConfig {
 }
 
 /// Executes a search on the provided game at a specified depth.
-pub struct Search<'a> {
-    /// The game to search on.
-    ///
-    /// This game will be copied when moves are applied to it.
-    game: &'a Game,
-
-    /// The result of the search, updated as-needed during search.
-    result: SearchResult,
+pub struct Search {
+    /// Number of nodes searched.
+    nodes: u64,
 
     /// An atomic flag to determine if the search should be cancelled at any time.
     ///
@@ -147,32 +142,23 @@ pub struct Search<'a> {
     config: SearchConfig,
 }
 
-impl<'a> Search<'a> {
-    /// Construct a new [`Search`] instance to execute on the provided [`Game`].
+impl Search {
+    /// Construct a new [`Search`] instance to execute.
     #[inline(always)]
-    pub fn new(game: &'a Game, is_searching: Arc<AtomicBool>, config: SearchConfig) -> Self {
-        let result = SearchResult {
-            // Initialize `bestmove` to the first move available
-            bestmove: game.into_iter().next(),
-            ..Default::default()
-        };
-
+    pub fn new(is_searching: Arc<AtomicBool>, config: SearchConfig) -> Self {
         Self {
-            game,
-            result,
+            nodes: 0,
             is_searching,
             config,
         }
     }
 
-    /// Start the search, returning its results if the search was successful.
+    /// Start the search on the supplied [`Game`], returning a [`SearchResult`].
     ///
     /// This is the entrypoint of the search, and prints UCI info before calling [`Self::iterative_deepening`],
     /// and concluding by sending the `bestmove` message and exiting.
-    pub fn start(mut self) -> SearchResult {
-        self.send_info(
-            UciInfo::new().string(format!("Starting search on {:?}", self.game.to_fen(),)),
-        );
+    pub fn start(mut self, game: &Game) -> SearchResult {
+        self.send_info(UciInfo::new().string(format!("Starting search on {:?}", game.to_fen(),)));
         // println!(
         //     "info string Soft timeout {}ms",
         //     self.config.soft_timeout.as_millis()
@@ -182,8 +168,7 @@ impl<'a> Search<'a> {
         //     self.config.hard_timeout.as_millis()
         // );
 
-        let res = self.iterative_deepening();
-        // let res = self.random_move();
+        let res = self.iterative_deepening(game);
 
         // Search has ended; send bestmove
         let response = UciResponse::BestMove {
@@ -193,7 +178,7 @@ impl<'a> Search<'a> {
 
         println!("{response}");
 
-        // Search has concluded, alert other threads that we are no longer searching
+        // Search has concluded, alert other thread(s) that we are no longer searching
         self.is_searching.store(false, Ordering::Relaxed);
 
         res
@@ -213,9 +198,17 @@ impl<'a> Search<'a> {
     /// However, with features such as move ordering, a/b pruning, and aspiration windows, ID enhances performance.
     ///
     /// After each iteration, we check if we've exceeded our `soft_timeout` and, if we haven't, we run a search at a greater depth.
-    fn iterative_deepening(&mut self) -> SearchResult {
+    fn iterative_deepening(&mut self, game: &Game) -> SearchResult {
+        // Initialize `bestmove` to the first move available
+        let mut result = SearchResult {
+            bestmove: game.into_iter().next(),
+            ..Default::default()
+        };
+
         // Start at depth 1 because a search at depth 0 makes no sense
         let mut depth = 1;
+        let alpha = -Score::INF;
+        let beta = Score::INF;
 
         // The actual Iterative Deepening loop
         while self.config.starttime.elapsed() < self.config.soft_timeout
@@ -224,29 +217,22 @@ impl<'a> Search<'a> {
         {
             // Reset score after each search, as there is no way to know what the bounds are.
             // We can use the score from the previous depth's search in Aspiration Windows: https://www.chessprogramming.org/Aspiration_Windows
-            self.result.score = -Score::INF;
+            result.score = -Score::INF;
 
             // If the search returned an error, it was cancelled, so exit the iterative deepening loop.
-            match self.negamax(*self.game, depth, 0, -Score::INF, Score::INF) {
+            match self.negamax(game, depth, 0, alpha, beta) {
                 // A new result was found, so update our best so far
                 Ok((bestmove, score)) => {
-                    self.result.bestmove = bestmove;
-                    self.result.score = score;
+                    result.bestmove = bestmove;
+                    result.score = score;
                 }
 
                 // The search was cancelled, so exit the ID loop.
                 Err(e) => {
                     self.send_info(UciInfo::new().string(format!(
                         "Search cancelled during depth {depth} while evaluating {} with score {}: {e}",
-                        self.result.bestmove.unwrap_or_default(),
-                        self.result.score
-                    )));
-
-                    self.send_info(UciInfo::new().string(format!(
-                        "Falling back to result from depth {}: {} with score {}",
-                        depth - 1,
-                        self.result.bestmove.unwrap_or_default(),
-                        self.result.score,
+                        result.bestmove.unwrap_or_default(),
+                        result.score
                     )));
 
                     break;
@@ -258,9 +244,9 @@ impl<'a> Search<'a> {
             self.send_info(
                 UciInfo::new()
                     .depth(depth)
-                    .nodes(self.result.nodes)
-                    .score(self.result.score.into_uci())
-                    .nps((self.result.nodes as f32 / elapsed.as_secs_f32()).trunc())
+                    .nodes(self.nodes)
+                    .score(result.score.into_uci())
+                    .nps((self.nodes as f32 / elapsed.as_secs_f32()).trunc())
                     .time(elapsed.as_millis()),
             );
 
@@ -268,9 +254,12 @@ impl<'a> Search<'a> {
             depth += 1;
         }
 
+        // Transfer the node count
+        result.nodes += self.nodes;
+
         // ID loop has concluded (either by finishing or timing out),
         //  so we return the result from the last successfully-completed search.
-        self.result
+        result
     }
 
     /// Primary location of search logic.
@@ -278,14 +267,14 @@ impl<'a> Search<'a> {
     /// Uses the [negamax](https://www.chessprogramming.org/Negamax) algorithm in a [fail soft](https://www.chessprogramming.org/Alpha-Beta#Negamax_Framework) framework.
     fn negamax(
         &mut self,
-        game: Game,
+        game: &Game,
         depth: usize,
         ply: i32,
         mut alpha: Score,
         beta: Score,
     ) -> Result<(Option<Move>, Score)> {
         // Regardless of how long we stay here, we've searched this node, so increment the counter.
-        self.result.nodes += 1;
+        self.nodes += 1;
 
         // If we've reached a terminal node, evaluate the current position
         if depth == 0 {
@@ -307,7 +296,7 @@ impl<'a> Search<'a> {
         }
 
         // Sort moves so that we look at "promising" ones first
-        moves.sort_by_cached_key(|mv| score_move(&game, mv));
+        moves.sort_by_cached_key(|mv| score_move(game, mv));
 
         // Start with a *really bad* initial score
         let mut best = -Score::INF;
@@ -320,8 +309,10 @@ impl<'a> Search<'a> {
             // Copy-make the new position
             let new_game = game.with_move_made(mv);
 
-            // Recurse
-            let score = -self.negamax(new_game, depth - 1, ply + 1, -beta, -alpha)?.1;
+            // Determine the score of making this move
+            let score = -self
+                .negamax(&new_game, depth - 1, ply + 1, -beta, -alpha)?
+                .1;
 
             // If we've found a better move than our current best, update the results
             if score > best {
@@ -349,15 +340,15 @@ impl<'a> Search<'a> {
     /// This is called when [`Search::negamax`] reaches a depth of 0, and has no recursion limit.
     fn quiescence_search(
         &mut self,
-        game: Game,
-        ply: i32,
+        game: &Game,
+        _ply: i32,
         mut alpha: Score,
         beta: Score,
     ) -> Result<(Option<Move>, Score)> {
-        self.result.nodes += 1;
+        self.nodes += 1;
 
         // Evaluate the current position, to serve as our baseline
-        let stand_pat = Evaluator::new(&game).eval();
+        let stand_pat = Evaluator::new(game).eval();
 
         // Beta cutoff; this position is "too good" and our opponent would never let us get here
         if stand_pat >= beta {
@@ -381,7 +372,7 @@ impl<'a> Search<'a> {
             return Ok((None, stand_pat));
         }
 
-        captures.sort_by_cached_key(|mv| score_move(&game, mv));
+        captures.sort_by_cached_key(|mv| score_move(game, mv));
 
         let mut best = stand_pat;
         let mut bestmove = captures.first().copied();
@@ -393,8 +384,10 @@ impl<'a> Search<'a> {
             // Copy-make the new position
             let new_game = game.with_move_made(mv);
 
-            // Recursively search our opponent's responses
-            let score = -self.quiescence_search(new_game, ply + 1, -beta, -alpha)?.1;
+            // Determine the score of making this move
+            let score = -self
+                .quiescence_search(&new_game, _ply + 1, -beta, -alpha)?
+                .1;
 
             // If we've found a better move than our current best, update our result
             if score > best {
@@ -433,7 +426,7 @@ impl<'a> Search<'a> {
             bail!("cancelled by external command");
         } else
         // Condition 3: We've exceeded the maximum amount of nodes we're allowed to search
-        if self.result.nodes >= self.config.max_nodes {
+        if self.nodes >= self.config.max_nodes {
             let nodes = self.config.max_nodes;
             bail!("exceeded node allowance of {nodes} nodes");
         } else {
@@ -443,6 +436,7 @@ impl<'a> Search<'a> {
     }
 }
 
+/// Applies a score to the provided move, intended to be used when ordering moves during search.
 #[inline(always)]
 fn score_move(game: &Game, mv: &Move) -> Score {
     // Safe unwrap because we can't move unless there's a piece at `from`
@@ -552,13 +546,17 @@ pub fn print_mvv_lva_table() {
 mod tests {
     use super::*;
 
-    fn ensure_is_mate_in(fen: &str, config: SearchConfig, moves: i32) -> SearchResult {
+    fn run_search(fen: &str, config: SearchConfig) -> SearchResult {
         let is_searching = Arc::new(AtomicBool::new(true));
         let game = fen.parse().unwrap();
 
-        let search = Search::new(&game, is_searching, config);
+        let search = Search::new(is_searching, config);
 
-        let res = search.start();
+        search.start(&game)
+    }
+
+    fn ensure_is_mate_in(fen: &str, config: SearchConfig, moves: i32) -> SearchResult {
+        let res = run_search(fen, config);
         assert!(
             res.score.is_mate(),
             "Search on {fen:?} with config {config:#?} produced result that is not mate.\nResult: {res:#?}"
@@ -600,12 +598,7 @@ mod tests {
         let fen = "k7/8/KQ6/8/8/8/8/8 b - - 0 1";
         let config = SearchConfig::default();
 
-        let is_searching = Arc::new(AtomicBool::new(true));
-        let game = fen.parse().unwrap();
-
-        let search = Search::new(&game, is_searching, config);
-
-        let res = search.start();
+        let res = run_search(fen, config);
         assert!(res.bestmove.is_none());
         assert_eq!(res.score, Score::DRAW,);
     }
@@ -619,12 +612,21 @@ mod tests {
             ..Default::default()
         };
 
-        let is_searching = Arc::new(AtomicBool::new(true));
-        let game = fen.parse().unwrap();
-
-        let search = Search::new(&game, is_searching, config);
-
-        let res = search.start();
+        let res = run_search(fen, config);
         assert_eq!(res.bestmove.unwrap(), "e7d8q");
+    }
+
+    #[test]
+    fn test_quick_search_finds_move() {
+        // If *any* legal move is available, it should be found, regardless of how much time was given.
+        let fen = chessie::FEN_STARTPOS;
+        let config = SearchConfig {
+            soft_timeout: Duration::from_millis(0),
+            hard_timeout: Duration::from_millis(0),
+            ..Default::default()
+        };
+
+        let res = run_search(fen, config);
+        assert!(res.bestmove.is_some());
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -140,9 +140,10 @@ pub struct Search {
 
     /// Configuration variables for this instance of the search.
     config: SearchConfig,
-
+    /*
     /// Previous positions encountered during search.
     history: Vec<Position>,
+     */
 }
 
 impl Search {
@@ -151,13 +152,13 @@ impl Search {
     pub fn new(
         is_searching: Arc<AtomicBool>,
         config: SearchConfig,
-        history: Vec<Position>,
+        // history: Vec<Position>,
     ) -> Self {
         Self {
             nodes: 0,
             is_searching,
             config,
-            history,
+            // history,
         }
     }
 
@@ -326,14 +327,12 @@ impl Search {
             let new_game = game.with_move_made(mv);
 
             // Determine the score of making this move
-            let score = if self.is_repetition(&new_game)
-            /*|| new_game.can_draw_by_fifty()*/
-            {
+            let score = if new_game.can_draw_by_fifty() {
                 // eprintln!("{mv} on {} is repetition", game.to_fen());
                 Score::DRAW
             } else {
                 // Append the move onto the history
-                self.history.push(*new_game.position());
+                // self.history.push(*new_game.position());
 
                 // Recurse
                 let score = -self
@@ -341,7 +340,7 @@ impl Search {
                     .1;
 
                 // Pop the move from the history
-                self.history.pop();
+                // self.history.pop();
 
                 score
             };
@@ -418,14 +417,12 @@ impl Search {
 
             // Normally, repetitions can't occur in QSearch, because captures are irreversible.
             // However, some QSearch extensions (quiet TT moves, all moves when in check, etc.) may be reversible.
-            let score = if self.is_repetition(&new_game)
-            /*|| new_game.can_draw_by_fifty()*/
-            {
+            let score = if new_game.can_draw_by_fifty() {
                 // eprintln!("{mv} on {} is repetition", game.to_fen());
                 Score::DRAW
             } else {
                 // Append the move onto the history
-                self.history.push(*new_game.position());
+                // self.history.push(*new_game.position());
 
                 // Recurse
                 let score = -self
@@ -433,7 +430,7 @@ impl Search {
                     .1;
 
                 // Pop the move from the history
-                self.history.pop();
+                // self.history.pop();
 
                 score
             };
@@ -484,6 +481,7 @@ impl Search {
         }
     }
 
+    /*
     /// Checks if `game` is a repetition, comparing it to previous positions
     #[inline(always)]
     fn is_repetition(&self, game: &Game) -> bool {
@@ -503,6 +501,7 @@ impl Search {
 
         false
     }
+     */
 }
 
 /// Applies a score to the provided move, intended to be used when ordering moves during search.
@@ -619,7 +618,8 @@ mod tests {
         let is_searching = Arc::new(AtomicBool::new(true));
         let game = fen.parse().unwrap();
 
-        let search = Search::new(is_searching, config, Vec::default());
+        // let search = Search::new(is_searching, config, Vec::default());
+        let search = Search::new(is_searching, config);
 
         search.start(&game)
     }


### PR DESCRIPTION
resolves #14 

Adds in draw detection for the following conditions:
- Insufficient material (courtesy of [this](https://github.com/dannyhammer/chessie/commit/083dee3dff8796dee36bdf4369b19810b2fa2b82) update in `chessie`)
- Draw by the 50-move rule
- 2-fold repetition detection

This one was messy (hence the 9 commits). To my knowledge (which may be incorrect), draws don't "add" much valuable data when running SPRT, and the player who causes the draw isn't penalized in any way. I hope to be incorrect about this, but I'm not sure how to discern if this is truly the case. Anyway, this led to confusing results when running SPRT. I would compare `dev` with `detect-draws` after adding in a check for 50-move detection, but the draw rate would still be astronomically high (the engines would draw over half the time). So that made it difficult to determine whether the changes were actually improving. I also had to continuously tweak the implementation of repetition detection because there were plenty small edge cases (I forgot to reset the `history` vector when `ucinewgame` was sent, for example). In the end, I tested repetition detection in Negamax and found it to gain, so I added in the remainder of the draw detection functions in Negamax and Qsearch and re-ran SPRT, only to get a near-identical result. My logic here was that I *know* the 50-move-rule and insufficient-material functions work as intended (they have been tested separately in `chessie`), and draws under those conditions seldom appear anyway, so it wasn't likely that they would make a significant difference by themselves.

Side note:
By default, QSearch only searches captures, so repetition detection and the 50-move rule can never apply. However, (and this is noted in a comment in the code), future extensions to QSearch (such as searching all moves when in check, or searching quiet TT moves) may cause QSearch to examine moves that could cause a draw by these conditions. As such, these conditions were added to QSearch.

---
SPRT
```
Elo   | 43.10 +- 15.01 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 10.00]
Games | N: 478 W: 128 L: 69 D: 281
Penta | [1, 23, 136, 74, 5]
```
https://pyronomy.pythonanywhere.com/test/16/

bench: 29560004