### PR TITLE
feat: added piece-square tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ In addition to the above UCI commands, Toad also supports the following custom c
 -   `moves`: Show all legal moves on the current position, or for a given square.
 -   `option`: Display the current value of the specified option.
 -   `perft`: Execute a perft on the current position at a supplied depth, printing the total nodes.
+-   `psqt`: View the piece-square tables (or a square's value) for the provided piece.
 -   `splitperft`: Execute a splitperft on the current position at a supplied depth, printing the total nodes.
 
 ### UCI Options
@@ -83,6 +84,8 @@ Toad uses several state-of-the-art techniques in [chess programming](https://www
         -   [TT moves](https://www.chessprogramming.org/Hash_Move)
 -   Evaluation:
     -   [Material difference](https://www.chessprogramming.org/Material)
+    -   [Piece-Square Tables](https://www.chessprogramming.org/Piece-Square_Tables) with initial values from [PeSTO](https://www.chessprogramming.org/PeSTO%27s_Evaluation_Function#Source_Code)
+    -   [Tapered Evaluation](https://www.chessprogramming.org/Tapered_Eval)
 
 More features will be added as development continues!
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use chessie::Square;
+use chessie::{Piece, Square};
 use clap::Parser;
 use uci_parser::UciCommand;
 
@@ -59,13 +59,35 @@ pub enum EngineCommand {
     /// Shows all legal moves in the current position.
     ///
     /// If `square` is provided, it will display all available moves from that square.
-    Moves { square: Option<Square> },
+    Moves {
+        square: Option<Square>,
+
+        // If set, a Bitboard of all possible moves will also be displayed
+        #[arg(short, long, default_value = "false")]
+        pretty: bool,
+    },
 
     /// Display the current value of the specified option.
     Option { name: String },
 
     /// Performs a perft on the current position at the supplied depth, printing total node count.
     Perft { depth: usize },
+
+    /// Outputs the Piece-Square table value for the provided piece at the provided square, scaled with the endgame weight.
+    ///
+    /// If no square was provided, the entire table(s) will be printed.
+    /// If no endgame weight was provided, it will be computed from the current game state.
+    #[command(aliases = ["psq", "pst"])]
+    Psqt {
+        /// The piece whose Piece-Square table value(s) to fetch.
+        piece: Piece,
+
+        /// Evaluate `piece` at `square`.
+        square: Option<Square>,
+
+        /// Evaluate `piece` at `square` with the provided endgame weight [0-100].
+        endgame_weight: Option<i32>,
+    },
 
     /// Performs a split perft on the current position at the supplied depth.
     #[command(alias = "sperft")]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -16,12 +16,12 @@ use std::{
 };
 
 use anyhow::{bail, Context, Result};
-use chessie::{print_perft, Game, Move, Position, Square};
+use chessie::{print_perft, Bitboard, Game, Move, Piece, Position, Square};
 use clap::Parser;
 use uci_parser::{UciCommand, UciInfo, UciOption, UciParseError, UciResponse};
 
 use crate::{
-    EngineCommand, Evaluator, Search, SearchConfig, SearchResult, TTable, BENCHMARK_FENS,
+    EngineCommand, Evaluator, Psqt, Search, SearchConfig, SearchResult, TTable, BENCHMARK_FENS,
     BYTES_IN_MB,
 };
 
@@ -144,7 +144,7 @@ impl Engine {
                     }
                 }
 
-                EngineCommand::Moves { square } => self.moves(square),
+                EngineCommand::Moves { square, pretty } => self.moves(square, pretty),
 
                 EngineCommand::Option { name } => {
                     if let Some(value) = self.get_option(&name) {
@@ -157,6 +157,12 @@ impl Engine {
                 EngineCommand::Perft { depth } => {
                     print_perft::<false, false>(&self.game, depth);
                 }
+
+                EngineCommand::Psqt {
+                    piece,
+                    square,
+                    endgame_weight: weight,
+                } => self.psqt(piece, square, weight),
 
                 EngineCommand::Splitperft { depth } => {
                     print_perft::<false, true>(&self.game, depth);
@@ -313,7 +319,8 @@ impl Engine {
         self.game.make_move(mv);
     }
 
-    fn moves(&self, square: Option<Square>) {
+    /// Executes the `moves` command, displaying all available moves on the board, or for the given square.
+    fn moves(&self, square: Option<Square>, pretty: bool) {
         // Get the legal moves
         let moves = if let Some(square) = square {
             self.game.get_legal_moves_from(square.into())
@@ -322,17 +329,24 @@ impl Engine {
         };
 
         // If there are none, print "(none)"
-        let moves_string = if moves.is_empty() {
-            String::from("(none)")
+        if moves.is_empty() {
+            println!("(none)")
         } else {
-            // Otherwise, join them by comma-space
-            moves
-                .into_iter()
+            // Join by comma-space
+            let string = moves
+                .iter()
                 .map(|mv| mv.to_string())
                 .collect::<Vec<_>>()
-                .join(", ")
-        };
-        println!("{moves_string}");
+                .join(", ");
+
+            // If pretty-printing, also display a Bitboard of all possible destinations
+            if pretty {
+                let bb = moves.iter().map(|mv| mv.to()).collect::<Bitboard>();
+                println!("{bb:?}\n\nmoves: {string}");
+            } else {
+                println!("{string}");
+            }
+        }
     }
 
     /// Resets the engine's internal game state.
@@ -371,6 +385,39 @@ impl Engine {
         }
 
         Ok(())
+    }
+
+    /// Executes the `psqt` command, printing the piece-square table info for the provided piece.
+    fn psqt(&self, piece: Piece, square: Option<Square>, endgame_weight: Option<i32>) {
+        // Compute the current endgame weight, if it wasn't provided
+        let weight = endgame_weight.unwrap_or(Evaluator::new(&self.game).endgame_weight);
+        // Fetch the middle-game and end-game tables
+        let (mg, eg) = Psqt::get_tables_for(piece.kind());
+
+        // If there was a square provided, print the eval for that square
+        if let Some(square) = square {
+            let mg_value = mg.get_relative(square, piece.color());
+            let eg_value = eg.get_relative(square, piece.color());
+
+            let value = Psqt::eval(piece, square, weight);
+            println!("[{mg_value}, {eg_value}] := {value}");
+        } else {
+            // Otherwise, print both the middle-game and end-game tables
+            let name = piece.name();
+
+            // If the piece is Black, flip the tables when printing
+            let f = |psqt| {
+                if piece.is_white() {
+                    format!("{psqt}")
+                } else {
+                    format!("{psqt:#}")
+                }
+            };
+
+            println!("Mid-game table for {name}:\n{}", f(mg));
+            println!();
+            println!("End-game table for {name}:\n{}", f(eg));
+        }
     }
 
     /// Sets the search flag to signal that the engine is starting/stopping a search.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -285,11 +285,12 @@ impl Engine {
     /// Executes the `eval` command, printing an evaluation of the current position.
     fn eval(&self, pretty: bool) {
         let evaluator = Evaluator::new(&self.game);
-        if pretty {
-            print!("{evaluator}\n\nScore: ");
-        }
 
-        println!("{}", evaluator.eval());
+        if pretty {
+            println!("{evaluator}");
+        } else {
+            println!("{}", evaluator.eval());
+        }
     }
 
     /// Display info about the internal hash table(s)
@@ -396,10 +397,8 @@ impl Engine {
 
         // If there was a square provided, print the eval for that square
         if let Some(square) = square {
-            let mg_value = mg.get_relative(square, piece.color());
-            let eg_value = eg.get_relative(square, piece.color());
-
-            let value = Psqt::eval(piece, square, weight);
+            let (mg_value, eg_value) = Psqt::evals(piece, square);
+            let value = mg_value.lerp(eg_value, weight);
             println!("[{mg_value}, {eg_value}] := {value}");
         } else {
             // Otherwise, print both the middle-game and end-game tables

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -8,7 +8,14 @@ use std::fmt;
 
 use chessie::{Board, Color, File, Game, PieceKind, Rank, Square};
 
-use crate::Score;
+use crate::{Psqt, Score};
+
+/// Initial material value of all pieces in a standard setup.
+const INITIAL_MATERIAL_VALUE: i32 = value_of(PieceKind::Pawn) * 16
+    + value_of(PieceKind::Knight) * 4
+    + value_of(PieceKind::Bishop) * 4
+    + value_of(PieceKind::Rook) * 4
+    + value_of(PieceKind::Queen) * 2;
 
 /// Encapsulates the logic of scoring a chess position.
 ///
@@ -18,13 +25,21 @@ use crate::Score;
 pub struct Evaluator<'a> {
     /// The game whose position to evaluate.
     game: &'a Game,
+
+    /// Percentage of game completion, in the range `[0, 100]`.
+    ///
+    /// Higher number means fewer pieces are on the board
+    pub(crate) endgame_weight: i32,
 }
 
 impl<'a> Evaluator<'a> {
     /// Construct a new [`Evaluator`], computing any important metadata.
     #[inline(always)]
     pub fn new(game: &'a Game) -> Self {
-        Self { game }
+        Self {
+            game,
+            endgame_weight: endgame_weight(game),
+        }
     }
 
     /// Evaluate this position from the side-to-move's perspective.
@@ -43,65 +58,32 @@ impl<'a> Evaluator<'a> {
     /// A score of 0 is considered equal.
     #[inline(always)]
     fn eval_for(self, color: Color) -> Score {
-        let material = material_difference(self.game, color);
-        Score(material)
-    }
-
-    #[inline(always)]
-    fn value_at(&self, square: Square) -> Option<i32> {
         self.game
-            .piece_at(square)
-            .map(|p| value_of(p.kind()) * p.color().negation_multiplier() as i32)
+            .board()
+            .iter()
+            .fold(Score::DRAW, |score, (square, piece)| {
+                let value = Psqt::eval(piece, square, self.endgame_weight);
+
+                if piece.color() == color {
+                    score + value
+                } else {
+                    score - value
+                }
+            })
     }
 
+    /// Fetches the value for the piece on the specified square, if one exists.
+    ///
+    /// Only used when printing the evaluator
     #[inline(always)]
-    fn normalize(&self, value: i32) -> f32 {
-        // let max = Score::MATE.0 as f32;
-        value as f32 / 100.0
+    fn value_at(&self, square: Square) -> Option<Score> {
+        self.game.piece_at(square).map(|piece| {
+            Score(
+                Psqt::eval(piece, square, self.endgame_weight)
+                    * piece.color().negation_multiplier() as i32,
+            )
+        })
     }
-}
-
-/// Returns a value of the provided `PieceKind`.
-///
-/// Values are obtained from here: <https://www.chessprogramming.org/Simplified_Evaluation_Function>
-#[inline(always)]
-pub const fn value_of(kind: PieceKind) -> i32 {
-    match kind {
-        PieceKind::Pawn => 100,
-        PieceKind::Knight => 320,
-        PieceKind::Bishop => 330,
-        PieceKind::Rook => 500,
-        PieceKind::Queen => 900,
-        PieceKind::King => 20_000,
-    }
-}
-
-/// Computes the difference in material on the board.
-///
-/// If positive, `color` has more material.
-/// If negative, `color.opponent()` has more material.
-/// If zero, both sides have equal material.
-#[inline(always)]
-pub fn material_difference(board: &Board, color: Color) -> i32 {
-    let mut friendly = 0;
-    let mut enemy = 0;
-    let opponent = color.opponent();
-
-    for kind in PieceKind::all_except_king() {
-        friendly += count_material_of(board, color, kind);
-
-        enemy += count_material_of(board, opponent, kind);
-    }
-
-    friendly - enemy
-}
-
-/// Counts the material value of the specified piece kind/color on the board.
-#[inline(always)]
-const fn count_material_of(board: &Board, color: Color, kind: PieceKind) -> i32 {
-    let pieces = board.piece_parts(color, kind);
-
-    (pieces.population() as i32) * value_of(kind)
 }
 
 impl fmt::Display for Evaluator<'_> {
@@ -130,10 +112,10 @@ impl fmt::Display for Evaluator<'_> {
             for file in File::iter() {
                 let square = Square::new(file, rank);
                 let score = if let Some(val) = self.value_at(square) {
-                    let s = if val > 0 {
-                        format!("+{}", self.normalize(val))
+                    let s = if val > Score::DRAW {
+                        format!("+{}", val.normalize())
                     } else {
-                        format!("{}", self.normalize(val))
+                        format!("{}", val.normalize())
                     };
 
                     format!("{s:^5}")
@@ -154,6 +136,78 @@ impl fmt::Display for Evaluator<'_> {
         for file in File::iter() {
             write!(f, "     {file}")?;
         }
+
+        writeln!(f, "\n\nEndgame: {}%", self.endgame_weight)?;
         Ok(())
     }
+}
+
+/// Returns a value of the provided `PieceKind`.
+///
+/// Values are obtained from here: <https://www.chessprogramming.org/Simplified_Evaluation_Function>
+#[inline(always)]
+pub const fn value_of(kind: PieceKind) -> i32 {
+    match kind {
+        PieceKind::Pawn => 100,
+        PieceKind::Knight => 320,
+        PieceKind::Bishop => 330,
+        PieceKind::Rook => 500,
+        PieceKind::Queen => 900,
+        PieceKind::King => 0, // King is invaluable, but 0 is easier to work with in computations
+    }
+}
+
+/*
+/// Computes the difference in material on the board.
+///
+/// If positive, `color` has more material.
+/// If negative, `color.opponent()` has more material.
+/// If zero, both sides have equal material.
+#[inline(always)]
+pub fn material_difference(board: &Board, color: Color) -> i32 {
+    let mut friendly = 0;
+    let mut enemy = 0;
+    let opponent = color.opponent();
+
+    for kind in PieceKind::all_except_king() {
+        friendly += count_material_of(board, color, kind);
+
+        enemy += count_material_of(board, opponent, kind);
+    }
+
+    friendly - enemy
+}
+ */
+
+/// Counts the material value of all pieces on the board
+///
+/// Does NOT count the material of the King, as it cannot be removed from the board.
+#[inline(always)]
+fn material_remaining(board: &Board) -> i32 {
+    PieceKind::all_except_king()
+        .into_iter()
+        .fold(0, |score, kind| {
+            score + board.kind(kind).population() as i32 * value_of(kind)
+        })
+}
+
+/*
+/// Counts the material value of the specified piece kind/color on the board.
+#[inline(always)]
+const fn count_material_of(board: &Board, color: Color, kind: PieceKind) -> i32 {
+    let pieces = board.piece_parts(color, kind);
+
+    (pieces.population() as i32) * value_of(kind)
+}
+ */
+
+/// Divides the original material value of the board by the current material value, yielding an `i32` in the range `[0, 100]`
+///
+/// Lower numbers are closer to the beginning of the game. Higher numbers are closer to the end of the game.
+///
+/// The King is ignored when performing this calculation.
+#[inline(always)]
+fn endgame_weight(board: &Board) -> i32 {
+    let remaining = INITIAL_MATERIAL_VALUE - material_remaining(board);
+    (remaining * 100 / INITIAL_MATERIAL_VALUE * 100) / 100
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ mod cli;
 mod engine;
 /// Evaluation of chess positions.
 mod eval;
+/// Piece-Square tables.
+mod psqt;
 /// Types and utilities for rating how good/bad a position is.
 mod score;
 /// Main engine logic; all search related code.
@@ -22,6 +24,7 @@ mod utils;
 pub use cli::*;
 pub use engine::*;
 use eval::*;
+use psqt::*;
 use score::*;
 use search::*;
 use ttable::*;

--- a/src/psqt.rs
+++ b/src/psqt.rs
@@ -1,0 +1,285 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::fmt;
+
+use chessie::{Color, File, Piece, PieceKind, Rank, Square};
+
+use crate::value_of;
+
+/// Piece-Square tables copied from [PeSTO](https://www.chessprogramming.org/PeSTO%27s_Evaluation_Function#Source_Code)
+#[rustfmt::skip]
+const PAWN_MG: Psqt = Psqt::new(PieceKind::Pawn, [
+      0,   0,   0,   0,   0,   0,  0,   0,
+     98, 134,  61,  95,  68, 126, 34, -11,
+     -6,   7,  26,  31,  65,  56, 25, -20,
+    -14,  13,   6,  21,  23,  12, 17, -23,
+    -27,  -2,  -5,  12,  17,   6, 10, -25,
+    -26,  -4,  -4, -10,   3,   3, 33, -12,
+    -35,  -1, -20, -23, -15,  24, 38, -22,
+      0,   0,   0,   0,   0,   0,  0,   0,
+]);
+
+#[rustfmt::skip]
+const PAWN_EG: Psqt = Psqt::new(PieceKind::Pawn, [
+      0,   0,   0,   0,   0,   0,   0,   0,
+    178, 173, 158, 134, 147, 132, 165, 187,
+     94, 100,  85,  67,  56,  53,  82,  84,
+     32,  24,  13,   5,  -2,   4,  17,  17,
+     13,   9,  -3,  -7,  -7,  -8,   3,  -1,
+      4,   7,  -6,   1,   0,  -5,  -1,  -8,
+     13,   8,   8,  10,  13,   0,   2,  -7,
+      0,   0,   0,   0,   0,   0,   0,   0,
+]);
+
+#[rustfmt::skip]
+const KNIGHT_MG: Psqt = Psqt::new(PieceKind::Knight, [
+    -167, -89, -34, -49,  61, -97, -15, -107,
+     -73, -41,  72,  36,  23,  62,   7,  -17,
+     -47,  60,  37,  65,  84, 129,  73,   44,
+      -9,  17,  19,  53,  37,  69,  18,   22,
+     -13,   4,  16,  13,  28,  19,  21,   -8,
+     -23,  -9,  12,  10,  19,  17,  25,  -16,
+     -29, -53, -12,  -3,  -1,  18, -14,  -19,
+    -105, -21, -58, -33, -17, -28, -19,  -23,
+]);
+
+#[rustfmt::skip]
+const KNIGHT_EG: Psqt = Psqt::new(PieceKind::Knight, [
+    -58, -38, -13, -28, -31, -27, -63, -99,
+    -25,  -8, -25,  -2,  -9, -25, -24, -52,
+    -24, -20,  10,   9,  -1,  -9, -19, -41,
+    -17,   3,  22,  22,  22,  11,   8, -18,
+    -18,  -6,  16,  25,  16,  17,   4, -18,
+    -23,  -3,  -1,  15,  10,  -3, -20, -22,
+    -42, -20, -10,  -5,  -2, -20, -23, -44,
+    -29, -51, -23, -15, -22, -18, -50, -64,
+]);
+
+#[rustfmt::skip]
+const BISHOP_MG: Psqt = Psqt::new(PieceKind::Bishop, [
+    -29,   4, -82, -37, -25, -42,   7,  -8,
+    -26,  16, -18, -13,  30,  59,  18, -47,
+    -16,  37,  43,  40,  35,  50,  37,  -2,
+     -4,   5,  19,  50,  37,  37,   7,  -2,
+     -6,  13,  13,  26,  34,  12,  10,   4,
+      0,  15,  15,  15,  14,  27,  18,  10,
+      4,  15,  16,   0,   7,  21,  33,   1,
+    -33,  -3, -14, -21, -13, -12, -39, -21,
+]);
+
+#[rustfmt::skip]
+const BISHOP_EG: Psqt = Psqt::new(PieceKind::Bishop, [
+    -14, -21, -11,  -8, -7,  -9, -17, -24,
+     -8,  -4,   7, -12, -3, -13,  -4, -14,
+      2,  -8,   0,  -1, -2,   6,   0,   4,
+     -3,   9,  12,   9, 14,  10,   3,   2,
+     -6,   3,  13,  19,  7,  10,  -3,  -9,
+    -12,  -3,   8,  10, 13,   3,  -7, -15,
+    -14, -18,  -7,  -1,  4,  -9, -15, -27,
+    -23,  -9, -23,  -5, -9, -16,  -5, -17,
+]);
+
+#[rustfmt::skip]
+const ROOK_MG: Psqt = Psqt::new(PieceKind::Rook, [
+     32,  42,  32,  51, 63,  9,  31,  43,
+     27,  32,  58,  62, 80, 67,  26,  44,
+     -5,  19,  26,  36, 17, 45,  61,  16,
+    -24, -11,   7,  26, 24, 35,  -8, -20,
+    -36, -26, -12,  -1,  9, -7,   6, -23,
+    -45, -25, -16, -17,  3,  0,  -5, -33,
+    -44, -16, -20,  -9, -1, 11,  -6, -71,
+    -19, -13,   1,  17, 16,  7, -37, -26,
+]);
+
+#[rustfmt::skip]
+const ROOK_EG: Psqt = Psqt::new(PieceKind::Rook, [
+    13, 10, 18, 15, 12,  12,   8,   5,
+    11, 13, 13, 11, -3,   3,   8,   3,
+     7,  7,  7,  5,  4,  -3,  -5,  -3,
+     4,  3, 13,  1,  2,   1,  -1,   2,
+     3,  5,  8,  4, -5,  -6,  -8, -11,
+    -4,  0, -5, -1, -7, -12,  -8, -16,
+    -6, -6,  0,  2, -9,  -9, -11,  -3,
+    -9,  2,  3, -1, -5, -13,   4, -20,
+]);
+
+#[rustfmt::skip]
+const QUEEN_MG: Psqt = Psqt::new(PieceKind::Queen, [
+    -28,   0,  29,  12,  59,  44,  43,  45,
+    -24, -39,  -5,   1, -16,  57,  28,  54,
+    -13, -17,   7,   8,  29,  56,  47,  57,
+    -27, -27, -16, -16,  -1,  17,  -2,   1,
+     -9, -26,  -9, -10,  -2,  -4,   3,  -3,
+    -14,   2, -11,  -2,  -5,   2,  14,   5,
+    -35,  -8,  11,   2,   8,  15,  -3,   1,
+     -1, -18,  -9,  10, -15, -25, -31, -50,
+]);
+
+#[rustfmt::skip]
+const QUEEN_EG: Psqt = Psqt::new(PieceKind::Queen, [
+     -9,  22,  22,  27,  27,  19,  10,  20,
+    -17,  20,  32,  41,  58,  25,  30,   0,
+    -20,   6,   9,  49,  47,  35,  19,   9,
+      3,  22,  24,  45,  57,  40,  57,  36,
+    -18,  28,  19,  47,  31,  34,  39,  23,
+    -16, -27,  15,   6,   9,  17,  10,   5,
+    -22, -23, -30, -16, -16, -23, -36, -32,
+    -33, -28, -22, -43,  -5, -32, -20, -41,
+]);
+
+#[rustfmt::skip]
+const KING_MG: Psqt = Psqt::new(PieceKind::King, [
+    -65,  23,  16, -15, -56, -34,   2,  13,
+     29,  -1, -20,  -7,  -8,  -4, -38, -29,
+     -9,  24,   2, -16, -20,   6,  22, -22,
+    -17, -20, -12, -27, -30, -25, -14, -36,
+    -49,  -1, -27, -39, -46, -44, -33, -51,
+    -14, -14, -22, -46, -44, -30, -15, -27,
+      1,   7,  -8, -64, -43, -16,   9,   8,
+    -15,  36,  12, -54,   8, -28,  24,  14,
+]);
+
+#[rustfmt::skip]
+const KING_EG: Psqt = Psqt::new(PieceKind::King, [
+    -74, -35, -18, -18, -11,  15,   4, -17,
+    -12,  17,  14,  17,  17,  38,  23,  11,
+     10,  17,  23,  15,  20,  45,  44,  13,
+     -8,  22,  24,  27,  26,  33,  26,   3,
+    -18,  -4,  21,  24,  27,  23,   9, -11,
+    -19,  -3,  11,  21,  23,  16,   7,  -9,
+    -27, -11,   4,  13,  14,   4,  -5, -17,
+    -53, -34, -21, -11, -28, -14, -24, -43
+]);
+
+/// A [Piece-Square Table](https://www.chessprogramming.org/Piece-Square_Tables) for use in evaluation.
+#[derive(Debug)]
+pub struct Psqt([i32; Square::COUNT]);
+
+impl Psqt {
+    /// Fetch the Piece-Square Table value for `piece` at `square`.
+    #[inline(always)]
+    pub fn eval(piece: Piece, square: Square, endgame_weight: i32) -> i32 {
+        let (mg, eg) = Self::get_tables_for(piece.kind());
+
+        // Get the rank-relative square for this piece
+        let square = square.rank_relative_to(piece.color());
+
+        // Interpolate between the mid-game and end-game tables
+        lerp_i32(mg.get(square), eg.get(square), endgame_weight)
+    }
+
+    /// Fetch the Piece-Square Tables (middle-game and end-game) for the provided [`PieceKind`].
+    #[inline(always)]
+    pub fn get_tables_for<'a>(kind: PieceKind) -> (&'a Self, &'a Self) {
+        match kind {
+            PieceKind::Pawn => (&PAWN_MG, &PAWN_EG),
+            PieceKind::Knight => (&KNIGHT_MG, &KNIGHT_EG),
+            PieceKind::Bishop => (&BISHOP_MG, &BISHOP_EG),
+            PieceKind::Rook => (&ROOK_MG, &ROOK_EG),
+            PieceKind::Queen => (&QUEEN_MG, &QUEEN_EG),
+            PieceKind::King => (&KING_MG, &KING_EG),
+        }
+    }
+
+    /// Creates a new [`Psqt`] for the provided [`PieceKind`] and array of values.
+    const fn new(kind: PieceKind, psqt: [i32; Square::COUNT]) -> Self {
+        let mut flipped = psqt;
+
+        let mut i = 0;
+        while i < psqt.len() {
+            // Flip the rank, not the file, so it can be used from White's perspective without modification
+            // Also add in the value of this piece
+            flipped[i] = psqt[i ^ 56] + value_of(kind);
+            // flipped[i] = value_of(kind); // Functions like a material-only eval
+            i += 1;
+        }
+
+        Self(flipped)
+    }
+
+    /// Get the value of this PSQT at the provided square.
+    #[inline(always)]
+    pub const fn get(&self, square: Square) -> i32 {
+        self.0[square.index()]
+    }
+
+    /// Get the value of this PSQT at the provided square, relative to `color`.
+    #[inline(always)]
+    pub const fn get_relative(&self, square: Square, color: Color) -> i32 {
+        self.get(square.rank_relative_to(color))
+    }
+}
+
+impl fmt::Display for Psqt {
+    /// Printing a [`Psq`] will display it in the same way it is written in the code (White's perspective).
+    ///
+    /// If the alternate formatter is used (`#`), it will print as if from Black's perspective.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Format actual PSQ values
+        for rank in Rank::iter().rev() {
+            write!(f, "{rank}")?;
+            write!(f, "| ")?;
+            for file in File::iter() {
+                let color = Color::from_bool(f.alternate());
+                let value = self.get_relative(Square::new(file, rank), color);
+                write!(f, "{value:3} ")?;
+            }
+            writeln!(f)?;
+        }
+        // Format line at bottom of board
+        write!(f, " +")?;
+        for _ in File::iter() {
+            write!(f, "----")?;
+        }
+        write!(f, "\n    ")?;
+        // Format file characters
+        for file in File::iter() {
+            write!(f, "{file}")?;
+            write!(f, "   ")?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Performs linear interpolation between `x` and `y` by `t`, as integer values.
+#[inline(always)]
+const fn lerp_i32(x: i32, y: i32, t: i32) -> i32 {
+    x + (y - x) * t / 100
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_eval_is_correct_for_colors() {
+        // For every possible endgame weight
+        for endgame_weight in 0..=100 {
+            // Over every possible square
+            for square in Square::iter() {
+                // For every piece
+                for kind in PieceKind::all() {
+                    // Assert that White's PSQT eval is equal to Black's equivalent PSQT eval
+                    let white = Psqt::eval(Piece::new(Color::White, kind), square, endgame_weight);
+                    let black = Psqt::eval(
+                        Piece::new(Color::Black, kind),
+                        square.rank_relative_to(Color::Black),
+                        endgame_weight,
+                    );
+
+                    assert_eq!(
+                        white,
+                        black,
+                        "{} on {square} (weight := {endgame_weight}%): {white} (white) != {black} (black)",
+                        kind.name()
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/score.rs
+++ b/src/score.rs
@@ -15,7 +15,7 @@ use crate::MAX_DEPTH;
 /// This value is internally capped at [`Self::INF`].
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
-pub struct Score(pub(crate) i32);
+pub struct Score(pub i32);
 
 impl Score {
     /// Largest possible score ever achievable.
@@ -118,6 +118,12 @@ impl Score {
     pub fn normalize(&self) -> f32 {
         // let max = Score::MATE.0 as f32;
         self.0 as f32 / 100.0
+    }
+
+    /// Performs linear interpolation between `self` and `other` by `t` where `t` is `[0, 100]`.
+    #[inline(always)]
+    pub const fn lerp(self, other: Self, t: i32) -> Self {
+        Self(self.0 + (other.0 - self.0) * t / 100)
     }
 }
 

--- a/src/score.rs
+++ b/src/score.rs
@@ -10,7 +10,7 @@ use uci_parser::UciScore;
 
 use crate::MAX_DEPTH;
 
-/// A numerical representation of the evaluation of a position / move.
+/// A numerical representation of the evaluation of a position / move, in units of ["centipawns"](https://www.chessprogramming.org/Score).
 ///
 /// This value is internally capped at [`Self::INF`].
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -109,6 +109,15 @@ impl Score {
     #[inline(always)]
     pub const fn abs(self) -> Self {
         Self(self.0.abs())
+    }
+
+    /// "Normalizes" a score so that it can be printed as a float.
+    ///
+    /// Presently, this just divides by 100, since a score represents a centipawn value.
+    #[inline(always)]
+    pub fn normalize(&self) -> f32 {
+        // let max = Score::MATE.0 as f32;
+        self.0 as f32 / 100.0
     }
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -418,7 +418,7 @@ impl<'a> Search<'a> {
     fn quiescence_search<const DEBUG: bool>(
         &mut self,
         game: &Game,
-        ply: i32,
+        _ply: i32,
         mut alpha: Score,
         beta: Score,
     ) -> Result<Score> {
@@ -477,7 +477,7 @@ impl<'a> Search<'a> {
                 self.history.push(*new_game.position());
 
                 // Recurse
-                let score = -self.quiescence_search::<DEBUG>(&new_game, ply + 1, -beta, -alpha)?;
+                let score = -self.quiescence_search::<DEBUG>(&new_game, _ply + 1, -beta, -alpha)?;
 
                 // Pop the move from the history
                 self.history.pop();
@@ -647,9 +647,9 @@ const MVV_LVA: [[i32; PieceKind::COUNT]; PieceKind::COUNT] = {
             // bench: 27609398 nodes 5716479 nps
             // let score = (victim * 10 + (count - attacker)) as i32;
 
-            // Default MVV-LVA; Assigns negative values for King attacks
-            // bench: 30937536 nodes 5867022 nps
-            // let score = 10 * value_of(vtm) - value_of(atk);
+            // Default MVV-LVA except that the King is assigned a value of 0 if he is attacking
+            // bench: 27032804 nodes 8136592 nps
+            let score = 10 * value_of(vtm) - value_of(atk);
 
             // If the attacker is the King, the score is half the victim's value.
             // This encourages the King to attack, but not as strongly as other pieces.
@@ -660,15 +660,6 @@ const MVV_LVA: [[i32; PieceKind::COUNT]; PieceKind::COUNT] = {
             //     // Standard MVV-LVA computation
             //     10 * value_of(vtm) - value_of(atk)
             // };
-
-            // Default MVV-LVA except that the King is assigned a value of 0 if he is attacking
-            // bench: 27032804 nodes 8136592 nps
-            let score = if attacker == count - 1 {
-                10 * value_of(vtm)
-            } else {
-                // Standard MVV-LVA computation
-                10 * value_of(vtm) - value_of(atk)
-            };
 
             matrix[attacker][victim] = score;
             victim += 1;


### PR DESCRIPTION
resolves #35 

Adds piece-square tables to improve evaluation. PSQT values are copied from [PeSTO](https://www.chessprogramming.org/PeSTO%27s_Evaluation_Function#Source_Code), and are expected to be tuned later.

`Evaluator` has been modified to generate two evaluations (mid-game and end-game) simultaneously, and then lerp once at the end. Further investigation should be done to determine how best to lerp between mg/eg values, and how best to determine "endgame percentage."

---
SPRT (unreal gainer):
```
Elo   | 533.69 +- 96.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.69 (-3.66, 3.66) [0.00, 5.00]
Games | N: 384 W: 360 L: 10 D: 14
Penta | [0, 1, 9, 13, 169]
```
https://pyronomy.pythonanywhere.com/test/22/

bench: 15602055