### PR TITLE
feat: added support for executing multiple commands on startup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ anyhow = "1.0.89"
 #chessie = { path = "../chessie/chessie" }
 chessie = { git = "https://github.com/dannyhammer/chessie.git" }
 clap = { version = "4.5.18", features = ["derive"] }
-#uci-parser = { path = "../uci-parser", features = ["parse-go-perft", "parse-position-kiwipete", "clamp-negatives"] }
-uci-parser = { git = "https://github.com/dannyhammer/uci-parser.git", features = ["parse-go-perft", "parse-position-kiwipete", "clamp-negatives"] }
-#uci-parser = { version = "0.1.0", features = ["parse-go-perft", "parse-position-kiwipete", "clamp-negatives"] }
+#uci-parser = { path = "../uci-parser", features = ["parse-go-perft", "parse-position-kiwipete", "clamp-negatives", "err-on-unused-input"] }
+uci-parser = { git = "https://github.com/dannyhammer/uci-parser.git", features = ["parse-go-perft", "parse-position-kiwipete", "clamp-negatives", "err-on-unused-input"] }
+#uci-parser = { version = "0.1.0", features = ["parse-go-perft", "parse-position-kiwipete", "clamp-negatives", "err-on-unused-input"] }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Code for parsing UCI commands and responses is handled by a crate of mine, [`uci
 
 The following UCI commands (and arguments) are supported:
 
+-   `debug [ on | off ]`
 -   `uci`
 -   `isready`
 -   `setoption name <x> [value <y>]`

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ It is built upon [`chessie`](https://crates.io/crates/chessie), my chess crate w
 
 By default, Toad will print its version and authors and await input via `stdin`.
 For convenience, you can run any of Toad's commands on startup and Toad will exit immediately after that command's execution.
+To run multiple commands on startup, pass them in with the `-c "<command>"` flag.
+You can pass in the `--no-exit` flag to continue execution after the command(s) have finished executing.
 Run the engine and execute the `help` command to see a list of available commands.
 
 ### UCI

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -17,7 +17,6 @@ use std::{
 
 use anyhow::{bail, Context, Result};
 use chessie::{print_perft, Bitboard, Game, Move, Piece, Position, Square};
-use clap::Parser;
 use uci_parser::{UciCommand, UciInfo, UciOption, UciParseError, UciResponse};
 
 use crate::{
@@ -77,6 +76,7 @@ impl Engine {
             search_thread: None,
             ttable: Arc::default(),
             debug: false,
+            // debug: true,
         }
     }
 
@@ -625,13 +625,13 @@ fn input_handler(sender: Sender<EngineCommand>) -> Result<()> {
 
             // If it's not a UCI command, check if it's an engine-specific command
             Err(UciParseError::UnrecognizedCommand { cmd: _ }) => {
-                match EngineCommand::try_parse_from(buf.split_ascii_whitespace()) {
+                match buf.parse() {
                     Ok(cmd) => sender
                         .send(cmd)
                         .context("Failed to send command to engine")?,
 
                     // If it wasn't a custom command, either, print an error.
-                    Err(err) => eprintln!("{err}"),
+                    Err(err) => err.print()?,
                 }
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,21 +4,88 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use clap::error::ErrorKind;
 use clap::Parser;
 use toad::{Engine, EngineCommand};
 
-fn main() {
-    let mut toad = Engine::new();
-    println!("{} by {}", toad.name(), toad.authors());
+#[derive(Debug, Parser)]
+struct Cli {
+    /// Execute command(s) upon engine startup.
+    #[arg(short, long, required = false)]
+    commands: Vec<EngineCommand>,
 
-    // If a command was provided, send it and then exit
-    if let Ok(cmd) = EngineCommand::try_parse_from(std::env::args_os().skip(1)) {
-        toad.send_command(cmd);
-        toad.send_command(EngineCommand::Exit { cleanup: true });
-    }
+    /// Do not exit the engine after the startup commands have executed.
+    #[arg(short, long, default_value = "false")]
+    no_exit: bool,
+}
+
+fn main() {
+    // Instantiate the engine
+    let mut toad = Engine::new();
+
+    // Parse CLI args, send startup command(s), etc.
+    init(&toad);
+
+    // Display metadata
+    println!("{} by {}", toad.name(), toad.authors());
 
     // Run the engine's main event loop
     if let Err(e) = toad.run() {
         eprintln!("{} encountered a fatal error: {e}", toad.name());
+    }
+}
+
+/// Initialize the engine, including parsing CLI args and sending startup command(s).
+fn init(toad: &Engine) {
+    // Attempt to parse command-line arguments, if applicable
+    match Cli::try_parse() {
+        // If successful, send any provided commands to the engine
+        Ok(cli) => {
+            // Whether we need to exit after executing the startup command(s)
+            let send_quit = !cli.no_exit && !cli.commands.is_empty(); // I know DeMorgan's laws; this is easier to read.
+
+            for cmd in cli.commands {
+                toad.send_command(cmd);
+            }
+
+            if send_quit {
+                toad.send_command(EngineCommand::Exit { cleanup: true });
+            }
+        }
+
+        // If unsuccessful, try parsing the input as a singular engine command
+        Err(cli_err) => {
+            // If the error was to display the help/version, do that
+            match cli_err.kind() {
+                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => cli_err.exit(),
+                _ => {}
+            }
+
+            // Skip the executable name
+            let args = std::env::args().skip(1).collect::<Vec<_>>().join(" ");
+
+            match args.parse() {
+                // If this succeeds, send it to the engine
+                Ok(cmd) => {
+                    eprintln!("Parsed {cmd:?}");
+                    toad.send_command(cmd);
+                    toad.send_command(EngineCommand::Exit { cleanup: true });
+                }
+
+                // If it fails, exit with the appropriate error
+                Err(cmd_err) => {
+                    // If the error was specific to the command, print it and exit
+                    match cmd_err.kind() {
+                        ErrorKind::InvalidSubcommand
+                        | ErrorKind::UnknownArgument
+                        | ErrorKind::DisplayHelp
+                        | ErrorKind::DisplayVersion => cmd_err.exit(),
+
+                        // Otherwise, just print the original error and exit
+                        _ => cli_err.exit(),
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -106,8 +106,22 @@ impl SearchConfig {
             // Only calculate timeouts if a time was provided
             if let Some(time) = time {
                 let inc = inc.unwrap_or(Duration::ZERO);
-                config.soft_timeout = time / 20 + inc / 2; // Soft Timeout: 5% of time remaining + 50% time increment
-                config.hard_timeout = time / 5 + inc / 2; // Hard Timeout: 20% of time remaining + 50% time increment
+
+                // INPUT: go wtime 8000 btime 8000 winc 80 binc 80
+
+                let timeout = time / 20 + 3 * inc / 4; // 5% of time remaining + 75% time increment
+
+                // info string Soft timeout := 460ms
+                config.soft_timeout = 2 * timeout / 2;
+                // info string Soft timeout := 306ms
+                // config.soft_timeout = 2 * timeout / 3;
+                // info string Hard timeout := 920ms
+                config.hard_timeout = 2 * timeout;
+
+                // info string Soft timeout := 440ms
+                // config.soft_timeout = time / 20 + inc / 2; // Soft Timeout: 5% of time remaining + 50% time increment
+                // info string Hard timeout := 1640ms
+                // config.hard_timeout = time / 5 + inc / 2; // Hard Timeout: 20% of time remaining + 50% time increment
             }
         }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -107,30 +107,8 @@ impl SearchConfig {
             if let Some(time) = time {
                 let inc = inc.unwrap_or(Duration::ZERO);
 
-                // INPUT: go wtime 8000 btime 8000 winc 80 binc 80
-
-                let timeout = time / 20 + inc / 2; // 5% of time remaining + 50% time increment
-
-                // info string Soft timeout := 440ms
-                config.soft_timeout = timeout;
-
-                // info string Soft timeout := 293ms
-                // config.soft_timeout = 2 * timeout / 3;
-
-                // info string Hard timeout := 880ms
-                // config.hard_timeout = 2 * timeout;
-
-                // info string Hard timeout := 1320ms
-                // config.hard_timeout = 3 * timeout;
-
-                // info string Hard timeout := 1760ms
-                config.hard_timeout = 4 * timeout;
-
-                // CURRENT WAY:
-                // info string Soft timeout := 440ms
-                // config.soft_timeout = time / 20 + inc / 2; // Soft Timeout: 5% of time remaining + 50% time increment
-                // info string Hard timeout := 1640ms
-                // config.hard_timeout = time / 5 + inc / 2; // Hard Timeout: 20% of time remaining + 50% time increment
+                config.soft_timeout = time / 20 + inc / 2; // Soft Timeout: 5% of time remaining + 50% time increment
+                config.hard_timeout = time / 5 + inc / 2; // Hard Timeout: 20% of time remaining + 50% time increment
             }
         }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -112,12 +112,21 @@ impl SearchConfig {
                 let timeout = time / 20 + 3 * inc / 4; // 5% of time remaining + 75% time increment
 
                 // info string Soft timeout := 460ms
-                // config.soft_timeout = 2 * timeout / 2;
-                // info string Soft timeout := 306ms
-                config.soft_timeout = 2 * timeout / 3;
-                // info string Hard timeout := 920ms
-                config.hard_timeout = 2 * timeout;
+                config.soft_timeout = timeout;
 
+                // info string Soft timeout := 306ms
+                // config.soft_timeout = 2 * timeout / 3;
+
+                // info string Hard timeout := 920ms
+                // config.hard_timeout = 2 * timeout;
+
+                // info string Hard timeout := 1380ms
+                // config.hard_timeout = 3 * timeout;
+
+                // info string Hard timeout := 1840ms
+                config.hard_timeout = 4 * timeout;
+
+                // CURRENT WAY:
                 // info string Soft timeout := 440ms
                 // config.soft_timeout = time / 20 + inc / 2; // Soft Timeout: 5% of time remaining + 50% time increment
                 // info string Hard timeout := 1640ms

--- a/src/search.rs
+++ b/src/search.rs
@@ -111,20 +111,20 @@ impl SearchConfig {
 
                 let timeout = time / 20 + inc / 2; // 5% of time remaining + 50% time increment
 
-                // info string Soft timeout := 460ms
+                // info string Soft timeout := 440ms
                 config.soft_timeout = timeout;
 
-                // info string Soft timeout := 306ms
+                // info string Soft timeout := 293ms
                 // config.soft_timeout = 2 * timeout / 3;
 
-                // info string Hard timeout := 920ms
+                // info string Hard timeout := 880ms
                 // config.hard_timeout = 2 * timeout;
 
-                // info string Hard timeout := 1380ms
-                config.hard_timeout = 3 * timeout;
+                // info string Hard timeout := 1320ms
+                // config.hard_timeout = 3 * timeout;
 
-                // info string Hard timeout := 1840ms
-                // config.hard_timeout = 4 * timeout;
+                // info string Hard timeout := 1760ms
+                config.hard_timeout = 4 * timeout;
 
                 // CURRENT WAY:
                 // info string Soft timeout := 440ms

--- a/src/search.rs
+++ b/src/search.rs
@@ -112,9 +112,9 @@ impl SearchConfig {
                 let timeout = time / 20 + 3 * inc / 4; // 5% of time remaining + 75% time increment
 
                 // info string Soft timeout := 460ms
-                config.soft_timeout = 2 * timeout / 2;
+                // config.soft_timeout = 2 * timeout / 2;
                 // info string Soft timeout := 306ms
-                // config.soft_timeout = 2 * timeout / 3;
+                config.soft_timeout = 2 * timeout / 3;
                 // info string Hard timeout := 920ms
                 config.hard_timeout = 2 * timeout;
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -109,7 +109,7 @@ impl SearchConfig {
 
                 // INPUT: go wtime 8000 btime 8000 winc 80 binc 80
 
-                let timeout = time / 20 + 3 * inc / 4; // 5% of time remaining + 75% time increment
+                let timeout = time / 20 + inc / 2; // 5% of time remaining + 50% time increment
 
                 // info string Soft timeout := 460ms
                 config.soft_timeout = timeout;
@@ -121,10 +121,10 @@ impl SearchConfig {
                 // config.hard_timeout = 2 * timeout;
 
                 // info string Hard timeout := 1380ms
-                // config.hard_timeout = 3 * timeout;
+                config.hard_timeout = 3 * timeout;
 
                 // info string Hard timeout := 1840ms
-                config.hard_timeout = 4 * timeout;
+                // config.hard_timeout = 4 * timeout;
 
                 // CURRENT WAY:
                 // info string Soft timeout := 440ms


### PR DESCRIPTION
resolves #31 

New:
- You can now pass UCI commands directly to the engine on startup without needing to use the `uci` prefix
- You can now pass multiple commands to the engine on startup with the `-c` flag
- Added a `--no-exit` flag to prevent engine from exiting after executing startup command(s)
- Help menus are a bit better


---
3k games:
```
Elo   | 2.43 +- 6.21 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=16MB
Games | N: 3002 W: 1198 L: 1177 D: 627
Penta | [59, 115, 1145, 110, 72]
```
https://pyronomy.pythonanywhere.com/test/29/
* SPRT was not necessary, as this was a non-functional change

bench: 15602055