### PR TITLE
feat: added PVS

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -611,6 +611,11 @@ fn score_move(game: &Game, mv: &Move, tt_move: Option<Move>) -> Score {
         score += MVV_LVA[kind][victim];
     }
 
+    // Promoting is also a good idea
+    if let Some(promotion) = mv.promotion() {
+        score += value_of(promotion);
+    }
+
     -score // We're sorting, so a lower number is better
 }
 


### PR DESCRIPTION
resolves #10 

Adds Principal Variation Search.

PVS by itself doesn't gain much, but we're also not *doing* anything in PV nodes yet. Knowing whether or not we're in a PV node is helpful for TT cutoffs, for example. So, for that reason, we're using a const generic `PV` into the search functions that tell us whether we're in a PV node.

---
SPRT:
```
Elo   | 9.81 +- 7.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 10.00]
Games | N: 4710 W: 1911 L: 1778 D: 1021
Penta | [257, 315, 1101, 402, 280]
```
https://pyronomy.pythonanywhere.com/test/31/

bench: 12944256