### PR TITLE
refactor: adjusted search code to not return `Result`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,6 @@ fn init(toad: &Engine) {
             match args.parse() {
                 // If this succeeds, send it to the engine
                 Ok(cmd) => {
-                    eprintln!("Parsed {cmd:?}");
                     toad.send_command(cmd);
                     toad.send_command(EngineCommand::Exit { cleanup: true });
                 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -611,11 +611,6 @@ fn score_move(game: &Game, mv: &Move, tt_move: Option<Move>) -> Score {
         score += MVV_LVA[kind][victim];
     }
 
-    // Promoting is also a good idea
-    if let Some(promotion) = mv.promotion() {
-        score += value_of(promotion);
-    }
-
     -score // We're sorting, so a lower number is better
 }
 


### PR DESCRIPTION
Refactors the code in `negamax` and `quiescence_search` to return `Score` values directly rather than returning a `Result<Score>`. If timeouts occur, the current `best` score is returned. If a timeout occurs, the `iterative_deepening` loop checks this and returns the result from the previous iteration.

---
Result of 4k games (no SPRT because non-functional change):
```
Elo   | 5.82 +- 6.72 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=16MB
Games | N: 4116 W: 1625 L: 1556 D: 935
Penta | [142, 210, 1298, 253, 155]
```
https://pyronomy.pythonanywhere.com/test/40/

bench: 12944256