### PR TITLE
refactor: refactored code to not use magic numbers

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -244,7 +244,7 @@ impl Engine {
 
             // Set up the game and start the search
             self.position(Some(fen), [])?;
-            self.search_thread = self.start_search::<true>(config);
+            self.search_thread = self.start_search::<false>(config);
 
             // Await the search, appending the node count once concluded.
             let res = self.stop_search().unwrap();
@@ -271,7 +271,7 @@ impl Engine {
         }
 
         // Re-set the internal game state.
-        // self.new_game();
+        self.new_game();
 
         Ok(())
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -21,7 +21,6 @@ use uci_parser::{UciCommand, UciInfo, UciOption, UciParseError, UciResponse};
 
 use crate::{
     EngineCommand, Evaluator, Psqt, Search, SearchConfig, SearchResult, TTable, BENCHMARK_FENS,
-    BYTES_IN_MB,
 };
 
 /// Default depth at which to run the benchmark searches.
@@ -245,7 +244,7 @@ impl Engine {
 
             // Set up the game and start the search
             self.position(Some(fen), [])?;
-            self.search_thread = self.start_search::<false>(config);
+            self.search_thread = self.start_search::<true>(config);
 
             // Await the search, appending the node count once concluded.
             let res = self.stop_search().unwrap();
@@ -272,7 +271,7 @@ impl Engine {
         }
 
         // Re-set the internal game state.
-        self.new_game();
+        // self.new_game();
 
         Ok(())
     }
@@ -298,11 +297,10 @@ impl Engine {
         let ttable = self.ttable();
 
         let size = ttable.size();
-        let mb = size / BYTES_IN_MB;
         let num = ttable.num_entries();
         let cap = ttable.capacity();
         let percent = num as f32 / cap as f32 * 100.0;
-        println!("TT info: {size} bytes ({mb} mb), {num}/{cap} entries ({percent:.2}%)");
+        println!("TT info: {size}mb @ {num}/{cap} entries ({percent:.2}% full)");
     }
 
     /// Clears all hash tables in the engine.
@@ -498,10 +496,14 @@ impl Engine {
 
     /// Convenience function to return an iterator over all UCI options this engine supports.
     fn options(&self) -> impl Iterator<Item = UciOption<&str>> {
-        let ttable_size = TTable::DEFAULT_SIZE / BYTES_IN_MB;
         [
             UciOption::button("Clear Hash"),
-            UciOption::spin("Hash", ttable_size as i32, 1, 1_024),
+            UciOption::spin(
+                "Hash",
+                TTable::DEFAULT_SIZE as i32,
+                TTable::MIN_SIZE as i32,
+                TTable::MAX_SIZE as i32,
+            ),
             UciOption::spin("Threads", 1, 1, 1),
         ]
         .into_iter()
@@ -512,20 +514,31 @@ impl Engine {
     /// Will return an error if `name` isn't a valid option or `value` is not a valid value for that option.
     fn set_option(&mut self, name: &str, value: Option<String>) -> Result<()> {
         match name {
+            // Clear all hash tables
             "Clear Hash" => self.clear_hash_tables(),
 
+            // Re-size the hash table
             "Hash" => {
                 let Some(value) = value.as_ref() else {
                     bail!("usage: setoption name hash value <value>");
                 };
 
-                let mb = &value
+                let mb = value
                     .parse::<usize>()
                     .context(format!("expected integer. got {value:?}"))?;
 
-                *self.ttable() = TTable::new(mb * BYTES_IN_MB); // multiply by # bytes in MB
+                // Ensure the value is within bounds
+                if mb < TTable::MIN_SIZE {
+                    bail!("Minimum value for Hash is {}mb", TTable::MIN_SIZE);
+                }
+                if mb > TTable::MAX_SIZE {
+                    bail!("Maximum value for Hash is {}mb", TTable::MAX_SIZE);
+                }
+
+                *self.ttable() = TTable::new(mb); // multiply by # bytes in MB
             }
 
+            // Set the number of search threads
             "Threads" => bail!("{} currently supports only 1 thread", self.name()),
 
             _ => {
@@ -555,7 +568,7 @@ impl Engine {
         let value = match opt.name {
             "Clear Hash" => String::default(),
 
-            "Hash" => format!("{}", self.ttable().size() / BYTES_IN_MB),
+            "Hash" => format!("{}", self.ttable().size()),
 
             "Threads" => String::from("1"),
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::fmt;
+use std::{cmp::Ordering, fmt};
 
 use chessie::{Board, Color, File, Game, PieceKind, Rank, Square};
 
@@ -147,12 +147,10 @@ impl fmt::Display for Evaluator<'_> {
 
         let score = self.eval_for(color);
 
-        let winning_side = if score > Score::DRAW {
-            Some(color)
-        } else if score < Score::DRAW {
-            Some(color.opponent())
-        } else {
-            None
+        let winning_side = match score.cmp(&Score::DRAW) {
+            Ordering::Greater => Some(color),
+            Ordering::Less => Some(color.opponent()),
+            Ordering::Equal => None,
         };
 
         writeln!(f, "\n\nEndgame: {}%", self.endgame_weight)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ mod score;
 mod search;
 /// Hash table for storing data during search.
 mod ttable;
+/// Constants and magic numbers that can be tuned to tweak engine performance.
+mod tune;
 /// Misc utility functions, constants, and types.
 mod utils;
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -459,7 +459,7 @@ impl<'a> Search<'a> {
         beta: Score,
     ) -> Score {
         // TODO: Is this supposed to go before or after the stand_pat comparison?
-        let original_alpha = alpha;
+        // let original_alpha = alpha;
 
         // Evaluate the current position, to serve as our baseline
         let stand_pat = Evaluator::new(game).eval();
@@ -494,7 +494,7 @@ impl<'a> Search<'a> {
         captures.sort_by_cached_key(|mv| score_move(game, mv, tt_move));
 
         let mut best = stand_pat;
-        let mut bestmove = captures[0]; // Safe because we ensured `captures` is not empty
+        // let mut bestmove = captures[0]; // Safe because we ensured `captures` is not empty
 
         /****************************************************************************************************
          * Primary move loop
@@ -528,7 +528,7 @@ impl<'a> Search<'a> {
                     alpha = score;
 
                     // PV found
-                    bestmove = mv;
+                    // bestmove = mv;
                 }
 
                 // Fail soft beta-cutoff.
@@ -545,11 +545,11 @@ impl<'a> Search<'a> {
 
         // Save this node to the TTable IF AND ONLY IF we don't already have an entry with a BETTER move for this position.
         // Since QSearch doesn't search *every* move, we could possibly have a non-capture move that's better for this position than anything we found during this search.
-        let tt_entry = self.ttable.get(&game.key());
-        if tt_entry.is_none() || tt_entry.is_some_and(|entry| entry.score < best) {
-            // This could potentially be overriding good moves if the stored move was found at a higher ply than the current ply
-            self.save_to_tt::<DEBUG>(game.key(), bestmove, best, original_alpha, beta, 0, ply);
-        }
+        // let tt_entry = self.ttable.get(&game.key());
+        // if tt_entry.is_none() || tt_entry.is_some_and(|entry| entry.score < best) {
+        //     // This could potentially be overriding good moves if the stored move was found at a higher ply than the current ply
+        //     self.save_to_tt::<DEBUG>(game.key(), bestmove, best, original_alpha, beta, 0, ply);
+        // }
 
         best // fail-soft
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -285,6 +285,27 @@ impl<'a> Search<'a> {
         {
             // Start a new search at the current depth
             let score = self.negamax::<DEBUG, true>(game, result.depth, 0, alpha, beta);
+
+            // If we've ran out of time, we shouldn't update the score, because the last search iteration was forcibly cancelled.
+            // Instead, we should break out of the ID loop, using the result from the previous iteration
+            if self.should_stop() {
+                if DEBUG {
+                    if let Some(bestmove) = self.get_tt_bestmove::<false>(game.key()) {
+                        self.send_string(format!(
+                                "Search cancelled during depth {} while evaluating {bestmove} with score {score}",
+                                result.depth,
+                                ));
+                    } else {
+                        self.send_string(format!(
+                            "Search cancelled during depth {} with score {score} and no bestmove",
+                            result.depth,
+                        ));
+                    }
+                }
+                break;
+            }
+
+            // Otherwise, we need to update the "current" result with the results from the new search
             result.score = score;
 
             // Get the bestmove from the TTable

--- a/src/search.rs
+++ b/src/search.rs
@@ -285,27 +285,6 @@ impl<'a> Search<'a> {
         {
             // Start a new search at the current depth
             let score = self.negamax::<DEBUG, true>(game, result.depth, 0, alpha, beta);
-
-            // If we've ran out of time, we shouldn't update the score, because the last search iteration was forcibly cancelled.
-            // Instead, we should break out of the ID loop, using the result from the previous iteration
-            if self.should_stop() {
-                if DEBUG {
-                    if let Some(bestmove) = self.get_tt_bestmove::<false>(game.key()) {
-                        self.send_string(format!(
-                                "Search cancelled during depth {} while evaluating {bestmove} with score {score}",
-                                result.depth,
-                                ));
-                    } else {
-                        self.send_string(format!(
-                            "Search cancelled during depth {} with score {score} and no bestmove",
-                            result.depth,
-                        ));
-                    }
-                }
-                break;
-            }
-
-            // Otherwise, we need to update the "current" result with the results from the new search
             result.score = score;
 
             // Get the bestmove from the TTable

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -1,0 +1,37 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+// #[macro_export]
+// macro_rules! tunable {
+//     ($default:tt, $min:tt, $max:tt, $step: tt) => {
+//         $default
+//     };
+// }
+
+/// Divisor for computing the soft timeout of a search.
+macro_rules! soft_timeout_divisor {
+    () => {
+        20
+        // super::tunable!(20, 1, 100, 1)
+    };
+}
+pub(crate) use soft_timeout_divisor;
+
+/// Divisor for computing the hard timeout of a search.
+macro_rules! hard_timeout_divisor {
+    () => {
+        5
+    };
+}
+pub(crate) use hard_timeout_divisor;
+
+/// Divisor for computing how much of the time increment to use.
+macro_rules! time_inc_divisor {
+    () => {
+        2
+    };
+}
+pub(crate) use time_inc_divisor;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,7 +6,7 @@
 
  
 /// Number of bytes in a megabyte
-pub const BYTES_IN_MB: usize = 1_048_576;
+pub const BYTES_IN_MB: usize = 1024 * 1024;
 
 
 pub const BENCHMARK_FENS: [&str; 128] = 


### PR DESCRIPTION
resolves #42 

The primary change here is the introduction of `tune.rs`, which contains macros that expand into values that will be tuned later. Right now, the only values present are for determining soft/hard timeouts in a search. More will be added over time, though, such as for aspiration windows. No tuning is being done presently, and likely won't be done until the engine is 3k+, so the format of these macros will likely change in the future.

Aside from that, there are several small refactors, such as function/variable name changes, some extra comments, etc.

---
SPRT:
```
Elo   | 4.03 +- 4.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 7750 W: 3128 L: 3038 D: 1584
Penta | [234, 333, 2684, 357, 267]
```
https://pyronomy.pythonanywhere.com/test/49/

bench: 12944256