### PR TITLE
feat: added Aspiration Windows with gradual widening

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -400,21 +400,13 @@ impl<'a> Search<'a> {
                 let score =
                     self.negamax::<DEBUG, true>(game, result.depth, 0, window.alpha, window.beta);
 
-                // If the score fell outside of the aspiration window, widen it
-                // if window.fails_low(score) {
-                //     window.widen_down(score);
-                // } else if window.fails_high(score) {
-                //     window.widen_up(score);
-                // } else {
-                //     // Otherwise, the window is OK and we can use the score
-                //     break 'aspiration_window;
-                // }
-
-                // If the score fell outside the window, reset the windows to be infinite
-                if score <= window.alpha || score >= window.beta {
-                    window = AspirationWindow::infinite();
+                // If the score fell outside of the aspiration window, widen it gradually
+                if window.fails_low(score) {
+                    window.widen_down(score);
+                } else if window.fails_high(score) {
+                    window.widen_up(score);
                 } else {
-                    // Otherwise, the score is within the window, so we can leave this loop
+                    // Otherwise, the window is OK and we can use the score
                     break 'aspiration_window score;
                 }
 

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -43,3 +43,11 @@ macro_rules! initial_aspiration_window_size {
     };
 }
 pub(crate) use initial_aspiration_window_size;
+
+/// Minimum depth to incorporate Aspiration Windows into the Iterative Deepening search.
+macro_rules! min_aspiration_window_depth {
+    () => {
+        1
+    };
+}
+pub(crate) use min_aspiration_window_depth;

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -35,3 +35,11 @@ macro_rules! time_inc_divisor {
     };
 }
 pub(crate) use time_inc_divisor;
+
+/// Initial Aspiration Window size
+macro_rules! initial_aspiration_window_size {
+    () => {
+        25
+    };
+}
+pub(crate) use initial_aspiration_window_size;


### PR DESCRIPTION
resolves #17 

This PR implements Aspiration Windows into the search. Values for the initial aspiration window size and minimum depth at which to apply aspiration windows have been added to `tune.rs` for tuning later. Current impl starts at depth 2 with a window of 1/4 Pawn, then widens exponentially on each failure.

Big thanks to @Ciekce on the EP discord for providing me with [some](https://chess.swehosting.se/test/6205/) [references](https://chess.swehosting.se/test/6206/) for Elo gains, answering lots of my questions, and explaining some of the Stormphrax source code.


---
SPRT:
```
Elo   | 58.24 +- 24.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 10.00]
Games | N: 572 W: 278 L: 183 D: 111
Penta | [21, 39, 113, 50, 63]
```
https://pyronomy.pythonanywhere.com/test/57/

bench: 13474519