### PR TITLE
feat: tweaked Aspiration Windows to change size based on depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Toad uses several state-of-the-art techniques in [chess programming](https://www
     -   [Quiescence Search](https://www.chessprogramming.org/Quiescence_Search) in a fail soft framework.
     -   [Draw detection](https://www.chessprogramming.org/Draw) through insufficient material, 2-fold repetition, and the 50-move rule.
     -   [Transposition Table](https://www.chessprogramming.org/Transposition_Table)
+    -   [Principal Variation Search](https://www.chessprogramming.org/Principal_Variation_Search)
+    -   [Aspiration Windows](https://www.chessprogramming.org/Aspiration_Windows) with [gradual widening](https://www.chessprogramming.org/Aspiration_Windows#Gradual_Widening)
     -   Move Ordering:
         -   [MVV-LVA](https://www.chessprogramming.org/MVV-LVA)
         -   [TT moves](https://www.chessprogramming.org/Hash_Move)

--- a/src/search.rs
+++ b/src/search.rs
@@ -29,10 +29,7 @@ struct AspirationWindow {
 
     /// Upper bound of the window
     beta: Score,
-    /*
-    /// Value the window is centered around
-    center: Score,
-     */
+
     /// Number of times that a score has been returned above beta.
     beta_fails: i32,
 
@@ -42,32 +39,28 @@ struct AspirationWindow {
 
 impl AspirationWindow {
     /// Returns a delta value to change window's size.
-    #[inline(always)]
-    fn delta() -> Score {
-        Score(tune::initial_aspiration_window_size!())
-    }
-
-    /// Create a new, infinite window.
     ///
-    /// Useful as an initial window, before any bounds/scores are known
+    /// The value will differ depending on `depth`, with higher depths producing narrower windows.
     #[inline(always)]
-    fn infinite() -> Self {
-        Self {
-            alpha: -Score::INF,
-            beta: Score::INF,
-            alpha_fails: 0,
-            beta_fails: 0,
-        }
+    fn delta(depth: u8) -> Score {
+        let initial_size = tune::initial_aspiration_window_delta!();
+
+        // Gradually decrease the window size from `8*init` to `init`
+        let delta = ((initial_size << 3) / depth as i32).max(initial_size);
+
+        Score(delta)
     }
 
     /// Creates a new [`AspirationWindow`] centered around `score`.
-    fn new(score: Score) -> Self {
-        let delta = Self::delta();
-
+    #[inline(always)]
+    fn new(score: Score, depth: u8) -> Self {
         // If the score is mate, we expect search results to fluctuate, so set the windows to infinite.
-        let (alpha, beta) = if score.is_mate() {
+        // Also, we only want to use aspiration windows after certain depths, so check that, too.
+        let (alpha, beta) = if depth < tune::min_aspiration_window_depth!() || score.is_mate() {
             (-Score::INF, Score::INF)
         } else {
+            // Otherwise we build a window around the provided score.
+            let delta = Self::delta(depth);
             (
                 (score - delta).max(-Score::INF),
                 (score + delta).min(Score::INF),
@@ -86,9 +79,9 @@ impl AspirationWindow {
     ///
     /// This also resets the `beta` bound to `(alpha + beta) / 2`
     #[inline(always)]
-    fn widen_down(&mut self, score: Score) {
+    fn widen_down(&mut self, score: Score, depth: u8) {
         // Compute a gradually-increasing delta
-        let delta = Self::delta() * (1 << (self.alpha_fails + 1));
+        let delta = Self::delta(depth) * (1 << (self.alpha_fails + 1));
 
         // By convention, we widen both bounds on a fail low.
         self.beta = ((self.alpha + self.beta) / 2).min(Score::INF);
@@ -100,9 +93,9 @@ impl AspirationWindow {
 
     /// Widens the window's `beta` bound, expanding it upwards.
     #[inline(always)]
-    fn widen_up(&mut self, score: Score) {
+    fn widen_up(&mut self, score: Score, depth: u8) {
         // Compute a gradually-increasing delta
-        let delta = Self::delta() * (1 << (self.beta_fails + 1));
+        let delta = Self::delta(depth) * (1 << (self.beta_fails + 1));
 
         // Widen the beta bound
         self.beta = (score + delta).min(Score::INF);
@@ -386,13 +379,8 @@ impl<'a> Search<'a> {
             && self.is_searching.load(Ordering::Relaxed)
             && result.depth <= self.config.max_depth
         {
-            // If we've reached a sufficient depth, set the aspiration window around the previous iteration's score
-            let mut window = if result.depth > tune::min_aspiration_window_depth!() {
-                AspirationWindow::new(result.score)
-            } else {
-                // Otherwise, default to an infinite window
-                AspirationWindow::infinite()
-            };
+            // Create a new aspiration window for this search
+            let mut window = AspirationWindow::new(result.score, result.depth);
 
             // Get a score from the a/b search while using aspiration windows
             let score = 'aspiration_window: loop {
@@ -402,9 +390,9 @@ impl<'a> Search<'a> {
 
                 // If the score fell outside of the aspiration window, widen it gradually
                 if window.fails_low(score) {
-                    window.widen_down(score);
+                    window.widen_down(score, result.depth);
                 } else if window.fails_high(score) {
-                    window.widen_up(score);
+                    window.widen_up(score, result.depth);
                 } else {
                     // Otherwise, the window is OK and we can use the score
                     break 'aspiration_window score;

--- a/src/search.rs
+++ b/src/search.rs
@@ -88,7 +88,7 @@ impl AspirationWindow {
     #[inline(always)]
     fn widen_down(&mut self, score: Score) {
         // Compute a gradually-increasing delta
-        let delta = Self::delta() * (1 << self.alpha_fails + 1);
+        let delta = Self::delta() * (1 << (self.alpha_fails + 1));
 
         // By convention, we widen both bounds on a fail low.
         self.beta = ((self.alpha + self.beta) / 2).min(Score::INF);
@@ -102,7 +102,7 @@ impl AspirationWindow {
     #[inline(always)]
     fn widen_up(&mut self, score: Score) {
         // Compute a gradually-increasing delta
-        let delta = Self::delta() * (1 << self.beta_fails + 1);
+        let delta = Self::delta() * (1 << (self.beta_fails + 1));
 
         // Widen the beta bound
         self.beta = (score + delta).min(Score::INF);

--- a/src/search.rs
+++ b/src/search.rs
@@ -43,10 +43,12 @@ impl AspirationWindow {
     /// The value will differ depending on `depth`, with higher depths producing narrower windows.
     #[inline(always)]
     fn delta(depth: u8) -> Score {
-        let initial_size = tune::initial_aspiration_window_delta!();
+        let initial_delta = tune::initial_aspiration_window_delta!();
 
-        // Gradually decrease the window size from `8*init` to `init`
-        let delta = ((initial_size << 3) / depth as i32).max(initial_size);
+        let min_delta = tune::min_aspiration_window_delta!();
+
+        // Gradually decrease the window size from `8*init` to `min`
+        let delta = ((initial_delta << 3) / depth as i32).max(min_delta);
 
         Score(delta)
     }

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -39,10 +39,18 @@ pub(crate) use time_inc_divisor;
 /// Initial Aspiration Window size
 macro_rules! initial_aspiration_window_delta {
     () => {
-        10
+        25
     };
 }
 pub(crate) use initial_aspiration_window_delta;
+
+/// Initial Aspiration Window size
+macro_rules! min_aspiration_window_delta {
+    () => {
+        10
+    };
+}
+pub(crate) use min_aspiration_window_delta;
 
 /// Minimum depth to incorporate Aspiration Windows into the Iterative Deepening search.
 macro_rules! min_aspiration_window_depth {

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -37,12 +37,12 @@ macro_rules! time_inc_divisor {
 pub(crate) use time_inc_divisor;
 
 /// Initial Aspiration Window size
-macro_rules! initial_aspiration_window_size {
+macro_rules! initial_aspiration_window_delta {
     () => {
-        25
+        10
     };
 }
-pub(crate) use initial_aspiration_window_size;
+pub(crate) use initial_aspiration_window_delta;
 
 /// Minimum depth to incorporate Aspiration Windows into the Iterative Deepening search.
 macro_rules! min_aspiration_window_depth {


### PR DESCRIPTION
Aspiration Windows now change in size depending on the depth at which they were calculated. The idea here is that we are more likely to have a stable search at higher depths, so our AW can be narrower.

---
SPRT:
```
Elo   | 1.82 +- 4.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.96 (-2.94, 2.94) [0.00, 10.00]
Games | N: 12802 W: 5208 L: 5141 D: 2453
Penta | [846, 904, 2864, 911, 876]
```
https://pyronomy.pythonanywhere.com/test/60/


bench: 13225972