### PR TITLE
feat: added release pipeline through GitHub Actions

### DIFF
--- a/.github/workflows/compile-and-release.yml
+++ b/.github/workflows/compile-and-release.yml
@@ -1,0 +1,33 @@
+name: Compile and release
+
+on:
+    release:
+        types: [created]
+
+permissions:
+    contents: write
+
+jobs:
+    release:
+        name: release ${{ matrix.target }}
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - target: x86_64-pc-windows-gnu
+                      archive: zip
+                    - target: x86_64-unknown-linux-musl
+                      archive: tar.gz
+                    - target: x86_64-apple-darwin
+                      archive: zip
+        steps:
+            - uses: actions/checkout@master
+            - name: Compile and release
+              uses: rust-build/rust-build.action@v1.4.5
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  RUSTTARGET: ${{ matrix.target }}
+                  ARCHIVE_TYPES: ${{ matrix.archive }}
+                  EXTRA_FILES: "README.md CHANGELOG.md"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,24 +1,24 @@
-on:
-  push:
-    branches:
-      - main
-
-permissions:
-  contents: write
-  pull-requests: write
-
 name: release-please
 
+on:
+    push:
+        branches:
+            - main
+
+permissions:
+    contents: write
+    pull-requests: write
+
 jobs:
-  release-please:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: googleapis/release-please-action@v4
-        with:
-          # this assumes that you have created a personal access token
-          # (PAT) and configured it as a GitHub action secret named
-          # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
-          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
-          # this is a built-in strategy in release-please, see "Action Inputs"
-          # for more options
-          release-type: rust
+    release-please:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: googleapis/release-please-action@v4
+              with:
+                  # this assumes that you have created a personal access token
+                  # (PAT) and configured it as a GitHub action secret named
+                  # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
+                  token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+                  # this is a built-in strategy in release-please, see "Action Inputs"
+                  # for more options
+                  release-type: rust


### PR DESCRIPTION
resolves #1 

Adds a release pipeline based on [this example](https://github.com/dannyhammer/rust-release-pipeline) to automatically compile binaries for Windows, MacOS, and Linux.

bench: 13225972