### PR TITLE
fix: fixed bug causing `make` to fail when `sed` not present on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,18 +3,16 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 
-
-# Extract name and version from Cargo.toml
-NAME := $(shell sed -n 's/^name = "\(.*\)"/\1/p' Cargo.toml)
-VERSION := $(shell sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml)
-
-# If on Windows, add the .exe extension to the executable
+# If on Windows, add the .exe extension to the executable and use PowerShell instead of `sed`
 ifeq ($(OS),Windows_NT)
 	EXT := .exe
+	NAME := $(shell powershell -Command "(Get-Content Cargo.toml | Select-String '^name =').Line -replace '.*= ', '' -replace '\"', ''")
+	VERSION := $(shell powershell -Command "(Get-Content Cargo.toml | Select-String '^version =').Line -replace '.*= ', '' -replace '\"', ''")
 else
 	EXT := 
+	NAME := $(shell sed -n 's/^name = "\(.*\)"/\1/p' Cargo.toml)
+	VERSION := $(shell sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml)
 endif
-
 
 # OpenBench specifies that the binary name should be changeable with the EXE parameter
 ifndef EXE

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-# Toad - A UCI chess engine, written in Rust.
+# Toad - A UCI-compatible toy chess engine
 
 Toad is a work-in-progress [chess engine](https://en.wikipedia.org/wiki/Chess_engine), and serves as my personal excuse to write fun code in Rust.
 It is built upon my [`chessie`](https://crates.io/crates/chessie) crate, which is the "core" library that handles move generation and all other rules of chess.
 
+Up for a game? Play against Toad on [Lichess](https://lichess.org/@/toad-bot)!
+
 ## Overview
 
-By default, Toad will print its version and authors and await input via `stdin`.
+By default, running Toad will cause it to print its version and authors and await input via `stdin`.
 For convenience, you can run any of Toad's commands on startup and Toad will exit immediately after that command's execution.
 To run multiple commands on startup, pass them in with the `-c "<command>"` flag.
 You can pass in the `--no-exit` flag to continue execution after the command(s) have finished executing.


### PR DESCRIPTION
resolves #46 

Adds in a PowerShell script equivalent to the `sed` script to fetch the name and version from `Cargo.toml` when compiling. Only executes if running `make` on Windows.

---
bench: 13225972