### PR TITLE
refactor: misc refactors

### DIFF
--- a/src/score.rs
+++ b/src/score.rs
@@ -191,6 +191,18 @@ impl std::ops::Neg for Score {
     }
 }
 
+impl PartialEq<i32> for Score {
+    fn eq(&self, other: &i32) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl PartialOrd<i32> for Score {
+    fn partial_cmp(&self, other: &i32) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(other)
+    }
+}
+
 impl fmt::Display for Score {
     #[inline(always)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/search.rs
+++ b/src/search.rs
@@ -237,7 +237,7 @@ impl Default for SearchConfig {
 }
 
 /// Executes a search on the provided game at a specified depth.
-pub struct Search<'a, V> {
+pub struct Search<'a, const LOG: u8, V> {
     /// Number of nodes searched.
     nodes: u64,
 
@@ -259,7 +259,7 @@ pub struct Search<'a, V> {
     variant: PhantomData<&'a V>,
 }
 
-impl<'a, V: Variant> Search<'a, V> {
+impl<'a, const LOG: u8, V: Variant> Search<'a, LOG, V> {
     /// Construct a new [`Search`] instance to execute.
     #[inline(always)]
     pub fn new(
@@ -283,7 +283,7 @@ impl<'a, V: Variant> Search<'a, V> {
     /// This is the entrypoint of the search, and prints UCI info before starting iterative deepening.
     /// and concluding by sending the `bestmove` message and exiting.
     #[inline(always)]
-    pub fn start<const LOG: u8>(mut self, game: &Game) -> SearchResult {
+    pub fn start(mut self, game: &Game) -> SearchResult {
         if LOG.allows(LogLevel::Debug) {
             self.send_string(format!("Starting search on {:?}", game.to_fen()));
 
@@ -306,7 +306,7 @@ impl<'a, V: Variant> Search<'a, V> {
             }
         }
 
-        let res = self.iterative_deepening::<LOG>(game);
+        let res = self.iterative_deepening(game);
 
         if LOG.allows(LogLevel::Debug) {
             let hits = self.ttable.hits;
@@ -374,7 +374,7 @@ impl<'a, V: Variant> Search<'a, V> {
     /// However, with features such as move ordering, a/b pruning, and aspiration windows, ID enhances performance.
     ///
     /// After each iteration, we check if we've exceeded our `soft_timeout` and, if we haven't, we run a search at a greater depth.
-    fn iterative_deepening<const LOG: u8>(&mut self, game: &Game) -> SearchResult {
+    fn iterative_deepening(&mut self, game: &Game) -> SearchResult {
         // Initialize `bestmove` to the first move available
         let mut result = SearchResult {
             bestmove: game.into_iter().next(),
@@ -396,8 +396,7 @@ impl<'a, V: Variant> Search<'a, V> {
             // Get a score from the a/b search while using aspiration windows
             let score = 'aspiration_window: loop {
                 // Start a new search at the current depth
-                let score =
-                    self.negamax::<LOG, true>(game, result.depth, 0, window.alpha, window.beta);
+                let score = self.negamax::<true>(game, result.depth, 0, window.alpha, window.beta);
 
                 // If the score fell outside of the aspiration window, widen it gradually
                 if window.fails_low(score) {
@@ -413,9 +412,7 @@ impl<'a, V: Variant> Search<'a, V> {
                 // Instead, we should break out of the ID loop, using the result from the previous iteration
                 if self.search_cancelled() {
                     if LOG.allows(LogLevel::Debug) {
-                        if let Some(bestmove) =
-                            self.get_tt_bestmove::<{ LogLevel::None as u8 }>(game.key())
-                        {
+                        if let Some(bestmove) = self.get_tt_bestmove(game.key()) {
                             self.send_string(format!(
                                 "Search cancelled during depth {} while evaluating {} with score {score}",
                                 result.depth,
@@ -440,8 +437,7 @@ impl<'a, V: Variant> Search<'a, V> {
             result.score = score;
 
             // Get the bestmove from the TTable
-            // This is guaranteed to be a cache hit, so don't log it as such
-            result.bestmove = self.get_tt_bestmove::<{ LogLevel::None as u8 }>(game.key());
+            result.bestmove = self.ttable.get(&game.key()).map(|entry| entry.bestmove);
 
             // Send search info to the GUI
             if LOG.allows(LogLevel::Info) {
@@ -463,7 +459,7 @@ impl<'a, V: Variant> Search<'a, V> {
     /// Primary location of search logic.
     ///
     /// Uses the [negamax](https://www.chessprogramming.org/Negamax) algorithm in a [fail soft](https://www.chessprogramming.org/Alpha-Beta#Negamax_Framework) framework.
-    fn negamax<const LOG: u8, const PV: bool>(
+    fn negamax<const PV: bool>(
         &mut self,
         game: &Game,
         depth: u8,
@@ -471,13 +467,9 @@ impl<'a, V: Variant> Search<'a, V> {
         mut alpha: Score,
         beta: Score,
     ) -> Score {
-        // Regardless of how long we stay here, we've searched this node, so increment the counter.
-        // TODO: Move this below the recursive call, so that PVS re-searches don't cause it to increment (and do the same for qsearch)
-        self.nodes += 1;
-
         // If we've reached a terminal node, evaluate the current position
         if depth == 0 {
-            return self.quiescence::<LOG>(game, ply, alpha, beta);
+            return self.quiescence(game, ply, alpha, beta);
         }
 
         // If there are no legal moves, it's either mate or a draw.
@@ -495,7 +487,7 @@ impl<'a, V: Variant> Search<'a, V> {
         }
 
         // Sort moves so that we look at "promising" ones first
-        let tt_move = self.get_tt_bestmove::<LOG>(game.key());
+        let tt_move = self.get_tt_bestmove(game.key());
         moves.sort_by_cached_key(|mv| self.score_move(game, mv, tt_move));
 
         // Start with a *really bad* initial score
@@ -524,17 +516,18 @@ impl<'a, V: Variant> Search<'a, V> {
                  ****************************************************************************************************/
                 if i == 0 {
                     // Recurse on the principle variation
-                    score = -self.negamax::<LOG, PV>(&new, depth - 1, ply + 1, -beta, -alpha);
+                    score = -self.negamax::<PV>(&new, depth - 1, ply + 1, -beta, -alpha);
                 } else {
                     // Search with a null window
-                    score =
-                        -self.negamax::<LOG, false>(&new, depth - 1, ply + 1, -alpha - 1, -alpha);
+                    score = -self.negamax::<false>(&new, depth - 1, ply + 1, -alpha - 1, -alpha);
 
                     // If it failed, perform a full re-search with the full a/b bounds
                     if alpha < score && score < beta {
-                        score = -self.negamax::<LOG, PV>(&new, depth - 1, ply + 1, -beta, -alpha);
+                        score = -self.negamax::<PV>(&new, depth - 1, ply + 1, -beta, -alpha);
                     }
                 };
+
+                self.nodes += 1; // We've now searched this node
 
                 // Pop the move from the history
                 self.prev_positions.pop();
@@ -567,7 +560,7 @@ impl<'a, V: Variant> Search<'a, V> {
         }
 
         // Save this node to the TTable
-        self.save_to_tt::<LOG>(game.key(), bestmove, best, original_alpha, beta, depth, ply);
+        self.save_to_tt(game.key(), bestmove, best, original_alpha, beta, depth, ply);
 
         best
     }
@@ -576,13 +569,7 @@ impl<'a, V: Variant> Search<'a, V> {
     ///
     /// A search that looks at only possible captures and capture-chains.
     /// This is called when [`Search::negamax`] reaches a depth of 0, and has no recursion limit.
-    fn quiescence<const LOG: u8>(
-        &mut self,
-        game: &Game,
-        _ply: i32,
-        mut alpha: Score,
-        beta: Score,
-    ) -> Score {
+    fn quiescence(&mut self, game: &Game, _ply: i32, mut alpha: Score, beta: Score) -> Score {
         // Evaluate the current position, to serve as our baseline
         let stand_pat = Evaluator::new(game).eval();
 
@@ -608,11 +595,7 @@ impl<'a, V: Variant> Search<'a, V> {
             return stand_pat;
         }
 
-        // Everything before this point is the same as if we called `eval()` in Negamax
-        // If we made it here, then we're examining this node
-        self.nodes += 1;
-
-        let tt_move = self.get_tt_bestmove::<LOG>(game.key());
+        let tt_move = self.get_tt_bestmove(game.key());
         captures.sort_by_cached_key(|mv| self.score_move(game, mv, tt_move));
 
         let mut best = stand_pat;
@@ -635,7 +618,8 @@ impl<'a, V: Variant> Search<'a, V> {
             } else {
                 self.prev_positions.push(*new.position());
 
-                score = -self.quiescence::<LOG>(&new, _ply + 1, -beta, -alpha);
+                score = -self.quiescence(&new, _ply + 1, -beta, -alpha);
+                self.nodes += 1; // We've now searched this node
 
                 self.prev_positions.pop();
             }
@@ -667,7 +651,7 @@ impl<'a, V: Variant> Search<'a, V> {
         }
 
         // Save this node to the TTable
-        // self.save_to_tt::<LOG>(game.key(), bestmove, best, original_alpha, beta, 0, ply);
+        // self.save_to_tt(game.key(), bestmove, best, original_alpha, beta, 0, ply);
 
         best // fail-soft
     }
@@ -710,7 +694,7 @@ impl<'a, V: Variant> Search<'a, V> {
 
     /// Saves the provided data to an entry in the TTable.
     #[allow(clippy::too_many_arguments)]
-    fn save_to_tt<const LOG: u8>(
+    fn save_to_tt(
         &mut self,
         key: ZobristKey,
         bestmove: Move,
@@ -732,7 +716,7 @@ impl<'a, V: Variant> Search<'a, V> {
     }
 
     /// Gets the bestmove for the provided position from the TTable, if it exists.
-    fn get_tt_bestmove<const LOG: u8>(&mut self, key: ZobristKey) -> Option<Move> {
+    fn get_tt_bestmove(&mut self, key: ZobristKey) -> Option<Move> {
         let mv = self.ttable.get(&key).map(|entry| entry.bestmove);
 
         if LOG.allows(LogLevel::Debug) {
@@ -869,9 +853,13 @@ mod tests {
         let game = fen.parse().unwrap();
 
         let mut ttable = Default::default();
-        let search = Search::<Standard>::new(is_searching, config, Default::default(), &mut ttable);
-
-        search.start::<{ LogLevel::None as u8 }>(&game)
+        Search::<{ LogLevel::None as u8 }, Standard>::new(
+            is_searching,
+            config,
+            Default::default(),
+            &mut ttable,
+        )
+        .start(&game)
     }
 
     fn ensure_is_mate_in(fen: &str, config: SearchConfig, moves: i32) -> SearchResult {


### PR DESCRIPTION
refactor: moved node counter after recursive call

refactor: hash tables are cleared after each bench

refactor: cleaned up const generics a bit


---
SPRT:
```
Elo   | 0.60 +- 6.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.04 (-2.94, 2.94) [-10.00, 0.00]
Games | N: 6368 W: 2586 L: 2575 D: 1207
Penta | [381, 442, 1530, 447, 384]
```
https://pyronomy.pythonanywhere.com/test/118/

bench: 14087451