### PR TITLE
fix: set `Score::BASE_MOVE_SCORE` to `0` (from `-32768`)

### DIFF
--- a/src/tune.rs
+++ b/src/tune.rs
@@ -74,8 +74,7 @@ pub(crate) use max_history_bonus;
 /// such as captures and hash moves.
 macro_rules! base_move_score {
     () => {
-        -32_768
-        // 0
+        0
     };
 }
 pub(crate) use base_move_score;


### PR DESCRIPTION
Honestly? I'm not entirely sure why this made a difference at all. Let alone a positive difference.

I suspect this difference will go away with #28, #68 or other features that affect move ordering.

---
SPRT:
```
Elo   | 12.65 +- 9.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 10.00]
Games | N: 3600 W: 1497 L: 1366 D: 737
Penta | [226, 255, 752, 296, 271]
```
https://pyronomy.pythonanywhere.com/test/127/

bench: 11371856