### PR TITLE
refactor: add better support for playing different chess variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["chess", "chess-engine", "uci"]
 [dependencies]
 anyhow = "1.0.89"
 arrayvec = "0.7.6"
-clap = { version = "4.5.18", features = ["derive"] }
+clap = { version = "4.5.18", features = ["derive", "string"] }
 #uci-parser = { path = "../uci-parser", features = ["parse-go-perft", "parse-position-kiwipete", "clamp-negatives", "err-on-unused-input"] }
 uci-parser = { git = "https://github.com/dannyhammer/uci-parser.git", features = ["parse-go-perft", "parse-position-kiwipete", "clamp-negatives", "err-on-unused-input"] }
 #uci-parser = { version = "0.2.0", features = ["parse-go-perft", "parse-position-kiwipete", "clamp-negatives", "err-on-unused-input"] }

--- a/README.md
+++ b/README.md
@@ -1,19 +1,24 @@
 # Toad - A UCI-compatible toy chess engine
 
 Toad is a work-in-progress [chess engine](https://en.wikipedia.org/wiki/Chess_engine), and serves as my personal excuse to write fun code in Rust.
-It was originally built upon my [`chessie`](https://crates.io/crates/chessie) crate, which is a chess library that handles board representation, move generation and all other rules of chess.
+It was [originally](https://github.com/dannyhammer/toad/pull/73) built upon my [`chessie`](https://crates.io/crates/chessie) crate, which is a chess library that handles board representation, move generation and all other rules of chess.
+Development progress is recorded automatically in the [changelog](./CHANGELOG.md).
+All progression/non-regression testing is done through [OpenBench](https://github.com/AndyGrant/OpenBench) instance hosted [here](https://pyronomy.pythonanywhere.com/index/).
+Strength of the latest version can be found on the [CCRL pages](https://computerchess.org.uk/ccrl/)- just search for `Toad`!
 
 Up for a game? Play against Toad on [Lichess](https://lichess.org/@/toad-bot)!
 
 ## Overview
 
-By default, running Toad will cause it to print its version and authors and await input via `stdin`.
+Being a chess engine, Toad is CLI application that, by default, will await commands via `stdin`.
+Toad does not have a GUI.
+There are some [commands](#custom-commands) you can use to view the board state and make moves, but Toad's primary use case is to be paired with a GUI or match runner like [en croissant](https://encroissant.org/) or [cutechess](https://github.com/cutechess/cutechess).
 For convenience, you can run any of Toad's commands on startup and Toad will exit immediately after that command's execution.
 To run multiple commands on startup, pass them in with the `-c "<command>"` flag.
 You can pass in the `--no-exit` flag to continue execution after the command(s) have finished executing.
 Run the engine and execute the `help` command to see a list of available commands, and `--help` to view all CLI flags and arguments.
 
-### UCI
+### UCI Commands
 
 Toad abides (mostly) by the [Universal Chess Interface](https://backscattering.de/chess/uci/) protocol, and communicates through `stdin` and `stdout`.
 The parsing of UCI commands and responses is handled by my [`uci-parser`](https://crates.io/crates/uci-parser) crate.
@@ -38,21 +43,23 @@ In addition to the above UCI commands, Toad also supports the following custom c
 
 ```
 Commands:
-  await       Await the current search, blocking until it completes
-  bench       Run a benchmark with the provided parameters
-  display     Print a visual representation of the current board state
-  eval        Print an evaluation of the current position
-  exit        Quit the engine
-  fen         Generate and print a FEN string for the current position
-  flip        Flips the side-to-move. Equivalent to playing a nullmove
-  hashinfo    Display information about the current hash table(s) in the engine
-  makemove    Apply the provided move to the game, if possible
-  moves       Shows all legal moves in the current position, or for a specific piece
-  option      Display the current value of the specified option
-  perft       Performs a perft on the current position at the supplied depth, printing total node count
-  psqt        Outputs the Piece-Square table value for the provided piece at the provided square, scaled with the endgame weight
-  splitperft  Performs a split perft on the current position at the supplied depth
-  help        Print this message or the help of the given subcommand(s)
+Commands:
+  await          Await the current search, blocking until it completes
+  bench          Run a benchmark with the provided parameters
+  changevariant  Change the variant of chess being played, or display the current variant
+  display        Print a visual representation of the current board state
+  eval           Print an evaluation of the current position
+  exit           Quit the engine
+  fen            Generate and print a FEN string for the current position
+  flip           Flips the side-to-move. Equivalent to playing a nullmove
+  hashinfo       Display information about the current hash table(s) in the engine
+  makemove       Apply the provided move to the game, if possible
+  moves          Shows all legal moves in the current position, or for a specific piece
+  option         Display the current value of the specified option
+  perft          Performs a perft on the current position at the supplied depth, printing total node count
+  psqt           Outputs the Piece-Square table value for the provided piece at the provided square, scaled with the endgame weight
+  splitperft     Performs a split perft on the current position at the supplied depth
+  help           Print this message or the help of the given subcommand(s)
 ```
 
 For specifics on how a command works, run `toad <COMMAND> --help`
@@ -95,6 +102,7 @@ If you are willing to test the installation and execution of Toad on other opera
     -   [Bitboard representation](https://www.chessprogramming.org/Bitboards).
     -   [Magic Bitboards](https://www.chessprogramming.org/Magic_Bitboards) for sliding piece attacks.
     -   [Repetition](https://www.chessprogramming.org/Repetitions) detection through [Zobrist Hashing](https://www.chessprogramming.org/Zobrist_Hashing).
+    -   [Chess960](https://en.wikipedia.org/wiki/Fischer_random_chess) support via the `UCI_Chess960` option or `changevariant` command.
 -   Search:
     -   Based on the [Negamax](https://www.chessprogramming.org/Negamax) algorithm.
     -   [Alpha-Beta Pruning](https://www.chessprogramming.org/Alpha-Beta#Negamax_Framework) in a fail soft framework.

--- a/src/board/moves.rs
+++ b/src/board/moves.rs
@@ -820,7 +820,7 @@ mod test {
 
     /// Helper function to assert that the `uci` move is parsed as `expected` on the position created from `fen`.
     fn test_move_parse(fen: &str, uci: &str, expected: Move) {
-        let pos = fen.parse::<Game>().unwrap();
+        let pos = fen.parse::<Game<Standard>>().unwrap();
 
         let mv = Move::from_uci(&pos, uci);
         assert!(mv.is_ok(), "{}", mv.unwrap_err());

--- a/src/board/moves.rs
+++ b/src/board/moves.rs
@@ -315,8 +315,8 @@ impl Move {
     ///
     /// # Example
     /// ```
-    /// # use toad::{Move, Square, MoveKind, PieceKind, Game, FEN_KIWIPETE};
-    /// let position = Game::from_fen("r3k2r/p1ppqpb1/bn2pnp1/3PN3/Pp2P3/2N2Q1p/1PPBBPPP/R3K2R b KQkq a3 0 1").unwrap();
+    /// # use toad::*;
+    /// let position = Game::<Standard>::from_fen("r3k2r/p1ppqpb1/bn2pnp1/3PN3/Pp2P3/2N2Q1p/1PPBBPPP/R3K2R b KQkq a3 0 1").unwrap();
     ///
     /// let capture = Move::from_uci(&position, "b4c3").unwrap();
     /// assert_eq!(capture.is_capture(), true);
@@ -333,8 +333,8 @@ impl Move {
     ///
     /// # Example
     /// ```
-    /// # use toad::{Move, Square, MoveKind, PieceKind, Game, FEN_KIWIPETE};
-    /// let position = Game::from_fen(FEN_KIWIPETE).unwrap();
+    /// # use toad::*;
+    /// let position = Game::<Standard>::from_fen(FEN_KIWIPETE).unwrap();
     ///
     /// let quiet = Move::from_uci(&position, "e1d1").unwrap();
     /// assert_eq!(quiet.is_quiet(), true);
@@ -422,9 +422,9 @@ impl Move {
     ///
     /// # Example
     /// ```
-    /// # use toad::{Move, Square, MoveKind, PieceKind, Game};
+    /// # use toad::*;
     /// // An sample test position for discovering promotion bugs.
-    /// let position = Game::from_fen("n1n5/PPPk4/8/8/8/8/4Kppp/5N1N b - - 0 1 ").unwrap();
+    /// let position = Game::<Standard>::from_fen("n1n5/PPPk4/8/8/8/8/4Kppp/5N1N b - - 0 1 ").unwrap();
     /// let b7c8b = Move::from_uci(&position, "b7c8b").unwrap();
     /// assert_eq!(b7c8b.promotion(), Some(PieceKind::Bishop));
     /// ```
@@ -446,12 +446,12 @@ impl Move {
     /// # Example
     /// ```
     /// # use toad::*;
-    /// let position = Game::from_fen("n1n5/PPPk4/8/8/8/8/4Kppp/5N1N b - - 0 1 ").unwrap();
+    /// let position = Game::<Standard>::from_fen("n1n5/PPPk4/8/8/8/8/4Kppp/5N1N b - - 0 1 ").unwrap();
     /// let b7c8b = Move::from_uci(&position, "b7c8b");
     /// assert_eq!(b7c8b.unwrap(), Move::new(Square::B7, Square::C8, MoveKind::promotion_capture(PieceKind::Bishop)));
     ///
     /// // Automatically parses castling moves in standard notation to use the KxR format
-    /// let position = Game::from_fen("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1").unwrap();
+    /// let position = Game::<Standard>::from_fen("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1").unwrap();
     /// let e1c1 = Move::from_uci(&position, "e1c1");
     /// // Rook is on A1
     /// assert_eq!(e1c1.unwrap(), Move::new(Square::E1, Square::A1, MoveKind::LongCastle));

--- a/src/board/perft.rs
+++ b/src/board/perft.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use super::Game;
+use super::{Game, Variant};
 
 /// Perform a perft at the specified depth, collecting only data about the number of possible positions (nodes).
 ///
@@ -12,7 +12,7 @@ use super::Game;
 /// rather than making them, recursing again, and returning 1 for each terminal case.
 /// If you do *not* want to use bulk counting, use [`perft_generic`].
 #[inline(always)]
-pub fn perft(game: &Game, depth: usize) -> u64 {
+pub fn perft<V: Variant>(game: &Game<V>, depth: usize) -> u64 {
     // Bulk counting; no need to recurse again just to apply a singular move and return 1.
     if depth == 1 {
         return game.get_legal_moves().len() as u64;
@@ -35,15 +35,18 @@ pub fn perft(game: &Game, depth: usize) -> u64 {
 /// rather than making them, recursing again, and returning 1 for each terminal case.
 /// If you do *not* want to use bulk counting, use [`perft_generic`].
 #[inline(always)]
-pub fn splitperft(game: &Game, depth: usize) -> u64 {
-    perft_generic::<true, true>(game, depth)
+pub fn splitperft<V: Variant>(game: &Game<V>, depth: usize) -> u64 {
+    perft_generic::<true, true, V>(game, depth)
 }
 
 /// Generic version of `perft` that allows you to specify whether to perform bulk counting and splitperft.
 ///
 /// If `BULK` is set to `true`, this will perform bulk counting.
 /// If `SPLIT` is set to `true`, this will perform a splitperft.
-pub fn perft_generic<const BULK: bool, const SPLIT: bool>(game: &Game, depth: usize) -> u64 {
+pub fn perft_generic<const BULK: bool, const SPLIT: bool, V: Variant>(
+    game: &Game<V>,
+    depth: usize,
+) -> u64 {
     // Bulk counting; no need to recurse again just to apply a singular move and return 1.
     if BULK && !SPLIT && depth == 1 {
         return game.get_legal_moves().len() as u64;
@@ -59,7 +62,7 @@ pub fn perft_generic<const BULK: bool, const SPLIT: bool>(game: &Game, depth: us
     //     .filter(|mv| game.is_legal(*mv))
     //     .fold(0, |nodes, mv| {
     game.get_legal_moves().into_iter().fold(0, |nodes, mv| {
-        let new_nodes = perft_generic::<BULK, false>(&game.with_move_made(mv), depth - 1);
+        let new_nodes = perft_generic::<BULK, false, V>(&game.with_move_made(mv), depth - 1);
 
         if SPLIT {
             println!("{mv:}\t{new_nodes}");

--- a/src/board/position.rs
+++ b/src/board/position.rs
@@ -54,7 +54,7 @@ pub enum GameVariant {
 /// For example, castling moves are printed differently in Chess960 than in standard chess.
 pub trait Variant
 where
-    Self: Debug + Default + PartialEq + Eq + Clone + Copy + Send + 'static,
+    Self: Copy + Send + 'static,
 {
     /// Formats a [`Move`] according to this variant's notation semantics.
     ///
@@ -907,11 +907,8 @@ impl<V: Variant> Game<V> {
         let opponent = color.opponent();
         let occupied = self.occupied();
 
-        // For Horde: return if no King, because there are no legal masks to compute.
-        let Some(sq) = self.king(color).to_square() else {
-            return;
-        };
-        self.king_square = sq;
+        // Find the King
+        self.king_square = self.king(color).to_square_unchecked();
 
         // Reset the pinmask and checkmask
         self.pinned = Bitboard::EMPTY_BOARD;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,7 +7,7 @@
 use std::str::FromStr;
 
 use crate::{GameVariant, Piece, Square};
-use clap::Parser;
+use clap::{builder::PossibleValue, Parser, ValueEnum};
 use uci_parser::UciCommand;
 
 /// A command to be sent to the engine.
@@ -146,5 +146,25 @@ impl FromStr for EngineCommand {
                 }
             }
         }
+    }
+}
+
+impl ValueEnum for GameVariant {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[GameVariant::Standard, GameVariant::Chess960]
+    }
+
+    fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
+        // By default, possible values are the variant's name (case-insensitive)
+        let name = format!("{self:?}");
+        let mut value = PossibleValue::new(&name).alias(name.to_ascii_lowercase());
+
+        // Some variants have additional aliases
+        match self {
+            GameVariant::Standard => {}
+            GameVariant::Chess960 => value = value.aliases(["960", "frc"]),
+        }
+
+        Some(value)
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@
 
 use std::str::FromStr;
 
-use crate::{Piece, Square};
+use crate::{GameVariant, Piece, Square};
 use clap::Parser;
 use uci_parser::UciCommand;
 
@@ -34,6 +34,16 @@ pub enum EngineCommand {
         /// Override the default benchmark depth.
         #[arg(short, long, required = false)]
         depth: Option<u8>,
+    },
+
+    /// Change the variant of chess being played, or display the current variant.
+    ///
+    /// This is handled automatically when setting the UCI options like UCI_Chess960,
+    /// but exists here for convenience.
+    #[command(aliases = ["variant", "v"])]
+    ChangeVariant {
+        /// The chess variant to switch to.
+        variant: Option<GameVariant>,
     },
 
     /// Print a visual representation of the current board state.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -34,8 +34,8 @@ pub struct Engine {
     ///
     /// This is modified whenever moves are played or new positions are given,
     /// and is reset whenever the engine is told to start a new game.
-    game: Game,
-
+    game: Game<Standard>,
+    // game: Game<Box<dyn Variant>>,
     /// All previous positions of `self.game`, including the current position.
     ///
     /// Updated when the engine makes a move or receives `position ... moves [move list]`.
@@ -492,6 +492,9 @@ impl Engine {
 
         // Clone the parameters that will be sent into the thread
         let game = self.game;
+        // let game = V::change_variant(self.game);
+        // let game: Game<V> = self.game.into();
+
         let is_searching = Arc::clone(&self.is_searching);
         let mut prev_positions = self.prev_positions.clone();
         // Cloning a vec doesn't clone its capacity, so we need to do that manually
@@ -507,7 +510,8 @@ impl Engine {
             let mut history = history.lock().unwrap();
 
             // Start the search, returning the result when completed.
-            Search::<LOG, V>::new(
+            Search::<LOG, Standard>::new(
+                // Search::<LOG, V>::new(
                 is_searching,
                 config,
                 prev_positions,

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ struct Cli {
     #[arg(short, long, required = false)]
     commands: Vec<EngineCommand>,
 
-    /// Do not exit the engine after the startup commands have executed.
+    /// Do not exit the engine after the startup commands (-c) have executed.
     #[arg(short, long, default_value = "false")]
     no_exit: bool,
 }
@@ -23,20 +23,6 @@ fn main() {
     // Instantiate the engine
     let mut toad = Engine::new();
 
-    // Parse CLI args, send startup command(s), etc.
-    handle_cli_args(&toad);
-
-    // Display metadata
-    println!("{} by {}", toad.name(), toad.authors());
-
-    // Run the engine's main event loop
-    if let Err(e) = toad.run() {
-        eprintln!("{} encountered a fatal error: {e}", toad.name());
-    }
-}
-
-/// Initialize the engine, including parsing CLI args and sending startup command(s).
-fn handle_cli_args(toad: &Engine) {
     // Attempt to parse command-line arguments, if applicable
     match Cli::try_parse() {
         // If successful, send any provided commands to the engine
@@ -87,4 +73,10 @@ fn handle_cli_args(toad: &Engine) {
             }
         }
     }
+
+    // Display metadata
+    println!("{} by {}", toad.name(), toad.authors());
+
+    // Run the engine's main event loop
+    toad.run();
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -336,7 +336,7 @@ impl<'a, const LOG: u8, V: Variant> Search<'a, LOG, V> {
     #[inline(always)]
     pub fn start(mut self, game: &Game<V>) -> SearchResult {
         if LOG.allows(LogLevel::Debug) {
-            self.send_string(format!("Starting search on {:?}", game.to_fen(false)));
+            self.send_string(format!("Starting search on {:?}", game.to_fen()));
 
             let soft = self.config.soft_timeout.as_millis();
             let hard = self.config.hard_timeout.as_millis();

--- a/src/ttable.rs
+++ b/src/ttable.rs
@@ -243,8 +243,8 @@ mod test {
     #[test]
     fn test_ttable() {
         // Create two positions whose Zobrist keys are equal mod 2
-        let pos1 = Game::default();
-        let mut pos2 = Game::from_fen(FEN_KIWIPETE).unwrap();
+        let pos1 = Game::<Standard>::default();
+        let mut pos2 = Game::<Standard>::from_fen(FEN_KIWIPETE).unwrap();
 
         // Ensure that the two positions have Zobrist keys that are both odd/even
         while pos1.key().inner() % 2 != pos2.key().inner() % 2 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,8 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::Move;
-
 /// Added functionality to `u8` to make the logging API cleaner.
 ///
 /// See [`LogLevel`] for more.
@@ -57,34 +55,6 @@ impl Default for GameVariant {
     #[inline(always)]
     fn default() -> Self {
         Self::Standard
-    }
-}
-
-/// Abstraction over the specific chess variant being played.
-///
-/// Different chess variants have slightly different ways of doing things.
-/// For example, castling moves are printed differently in Chess960 than in standard chess.
-pub trait Variant {
-    fn fmt_move(mv: Move) -> String;
-}
-
-/// Marker type for standard chess.
-#[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Copy)]
-pub struct Standard;
-impl Variant for Standard {
-    #[inline(always)]
-    fn fmt_move(mv: Move) -> String {
-        format!("{mv}")
-    }
-}
-
-/// Marker type for chess 960.
-#[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Copy)]
-pub struct Chess960;
-impl Variant for Chess960 {
-    #[inline(always)]
-    fn fmt_move(mv: Move) -> String {
-        format!("{mv:#}")
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -34,30 +34,6 @@ pub enum LogLevel {
     Debug,
 }
 
-/// Variant of chess being played by the Engine.
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
-pub enum GameVariant {
-    /// Standard chess
-    Standard,
-
-    /// Fischer Random chess
-    Chess960,
-}
-
-impl GameVariant {
-    #[inline(always)]
-    pub fn is_chess960(&self) -> bool {
-        matches!(self, Self::Chess960)
-    }
-}
-
-impl Default for GameVariant {
-    #[inline(always)]
-    fn default() -> Self {
-        Self::Standard
-    }
-}
-
 /// Number of bytes in a megabyte
 pub const BYTES_IN_MB: usize = 1024 * 1024;
 

--- a/tests/perft.rs
+++ b/tests/perft.rs
@@ -4,11 +4,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use toad::{perft_generic, Game};
+use toad::{perft_generic, Game, Standard};
 
 fn test_perft_fen_nodes(depth: usize, fen: &str, expected: u64) {
     let position = Game::from_fen(fen).unwrap();
-    let res = perft_generic::<false, false>(&position, depth);
+    let res = perft_generic::<false, false, Standard>(&position, depth);
     assert_eq!(res, expected, "PERFT(depth) failed on {fen}");
 }
 
@@ -221,7 +221,7 @@ fn do_perft(fen: &str, results: &[u64]) {
     let pos = Game::from_fen(fen).unwrap();
     for (depth, result) in results.iter().enumerate() {
         // let nodes = pos.perft_generic::<false, false>(idx as u8);
-        let nodes = perft_generic::<false, false>(&pos, depth);
+        let nodes = perft_generic::<false, false, Standard>(&pos, depth);
         assert_eq!(nodes, *result, "PERFT({depth}) failed on {fen}");
     }
 }


### PR DESCRIPTION
Refactors the engine and game's code to better support playing multiple variants of chess. No functional changes beyond the addition of the `changevariant` command, which may be removed at a later date.

As different variants have different rules (Chess960 has different castling notation, Horde has no King, etc.), I wanted way to cleanly have different variants abide by these different rules while also minimizing code duplication. My decision wast to have a marker trait called `Variant` on the `Game` struct, stored in a `PhantomData` as to not take up space. This marker trait has variant-specific functions such as formatting castling rights and displaying moves (right now, it only has functions that are different in standard vs chess960).
That was a simple change. The tricky part was refactoring the `Engine` to no longer have a `Game` field, since we can't change the variant without reconstructing a new `Game` instance. The solution was to break up `Engine::run`, the program's entrypoint that spawns a user input thread and loops upon received commands. Now `Engine::run` spawns the user input thread and then loops on calling `Engine::run_variant`, which is generic over `Variant`. Whenever `run_variant` returns, it will either return a `ControlFlow::Break`, denoting that the engine must exit, or a `ControlFlow::Continue(new_variant)`, indicating that the Engine should call `run_variant` again, but with the `new_variant` as the generic parameter.

---
SPRT:
```
Elo   | -0.83 +- 5.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [-10.00, 0.00]
Games | N: 9202 W: 3614 L: 3636 D: 1952
Penta | [503, 708, 2193, 702, 495]
```
https://pyronomy.pythonanywhere.com/test/137/

bench: 11371856