### PR TITLE
feat: null move pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Toad - A UCI-compatible toy chess engine
+# Toad 🐸 A UCI-compatible toy chess engine
 
 Toad is a work-in-progress [chess engine](https://en.wikipedia.org/wiki/Chess_engine), and serves as my personal excuse to write fun code in Rust.
 It was [originally](https://github.com/dannyhammer/toad/pull/73) built upon my [`chessie`](https://crates.io/crates/chessie) crate, which is a chess library that handles board representation, move generation and all other rules of chess.
@@ -42,7 +42,6 @@ The following UCI commands (and arguments) are supported:
 In addition to the above UCI commands, Toad also supports the following custom commands:
 
 ```
-Commands:
 Commands:
   await          Await the current search, blocking until it completes
   bench          Run a benchmark with the provided parameters
@@ -112,6 +111,7 @@ If you are willing to test the installation and execution of Toad on other opera
     -   [Transposition Table](https://www.chessprogramming.org/Transposition_Table).
     -   [Principal Variation Search](https://www.chessprogramming.org/Principal_Variation_Search).
     -   [Aspiration Windows](https://www.chessprogramming.org/Aspiration_Windows) with [gradual widening](https://www.chessprogramming.org/Aspiration_Windows#Gradual_Widening).
+    -   [Null Move Pruning](https://www.chessprogramming.org/Null_Move_Pruning).
     -   Move Ordering:
         -   [MVV-LVA](https://www.chessprogramming.org/MVV-LVA) with relative piece values `K < P < N < B < R < Q`, so `KxR` is ordered before `PxR`.
         -   [Hash moves](https://www.chessprogramming.org/Hash_Move).
@@ -135,3 +135,5 @@ More people have helped me on this journey than I can track, but I'll name a few
 -   [Analog-Hors](https://github.com/analog-hors), for an excellent [article on magic bitboards](https://analog-hors.github.io/site/magic-bitboards/)
 -   The authors of [viridithas](https://github.com/cosmobobak/viridithas/) and [Stormphrax](https://github.com/Ciekce/Stormphrax), for allowing their engines to be open source and for answering all my silly questions.
 -   [Andrew Grant](https://github.com/AndyGrant/) for creating [OpenBench](https://github.com/AndyGrant/OpenBench) and being willing to help me with its setup and use.
+-   The authors of [Yukari](https://github.com/yukarichess/yukari) for motivation through friendly competition.
+-   [Paul T](https://github.com/DeveloperPaul123), for feedback on my [`uci-parser`](https://crates.io/crates/uci-parser) crate.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 
 /// Default depth at which to run the benchmark searches.
-const BENCH_DEPTH: u8 = 7;
+const BENCH_DEPTH: u8 = 9;
 
 /// The Toad chess engine.
 #[derive(Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,8 +74,21 @@ fn main() {
         }
     }
 
-    // Display metadata
-    println!("{} by {}", toad.name(), toad.authors());
+    // Display banner and metadata
+    println!(
+        " (o)--(o)    {}\n/.______.\\   by {}\n\\________/",
+        toad.name(),
+        toad.authors()
+    );
+
+    //     println!(
+    //         "    o)__
+    //    (_  _`\\
+    //     z/z\\__)
+    // "
+    //     );
+
+    //     println!("   __(o\n /`_  _)\n(__/z/z");
 
     // Run the engine's main event loop
     toad.run();

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,15 +81,6 @@ fn main() {
         toad.authors()
     );
 
-    //     println!(
-    //         "    o)__
-    //    (_  _`\\
-    //     z/z\\__)
-    // "
-    //     );
-
-    //     println!("   __(o\n /`_  _)\n(__/z/z");
-
     // Run the engine's main event loop
     toad.run();
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -628,6 +628,9 @@ impl<'a, const LOG: u8, V: Variant> Search<'a, LOG, V> {
 
                 // Fail soft beta-cutoff.
                 if score >= beta {
+                    /****************************************************************************************************
+                     * History Heuristic
+                     ****************************************************************************************************/
                     // Simple bonus based on depth
                     let bonus = Score::HISTORY_MULTIPLIER * depth as i32 - Score::HISTORY_OFFSET;
 
@@ -849,6 +852,7 @@ impl<'a, const LOG: u8, V: Variant> Search<'a, LOG, V> {
         -score // We're sorting, so a lower number is better
     }
 
+    /// Returns `true` if null move pruning can be performed on the supplied `game`.
     #[inline(always)]
     fn can_perform_nmp(&self, game: &Game<V>, depth: u8) -> bool {
         // If the last move did not increment the fullmove, but *did* increment the halfmove, it was a nullmove
@@ -860,9 +864,9 @@ impl<'a, const LOG: u8, V: Variant> Search<'a, LOG, V> {
         let non_king_pawn_material =
             game.occupied() ^ game.kind(PieceKind::Pawn) ^ game.kind(PieceKind::King);
 
-        !game.is_in_check() // Can't play a nullmove if we're in check
-        && depth >= MIN_NMP_DEPTH // Can't play nullmove under a certain depth
+        depth >= MIN_NMP_DEPTH // Can't play nullmove under a certain depth
         && !last_move_was_nullmove // Can't play two nullmoves in a row
+        && !game.is_in_check() // Can't play a nullmove if we're in check
         && non_king_pawn_material.is_nonempty() // Can't play nullmove if insufficient material (only Kings and Pawns)
     }
 }

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -94,3 +94,19 @@ macro_rules! history_offset {
     };
 }
 pub(crate) use history_offset;
+
+/// Minimum depth at which null move pruning can be applied.
+macro_rules! min_nmp_depth {
+    () => {
+        3
+    };
+}
+pub(crate) use min_nmp_depth;
+
+/// Value to subtract from `depth` when applying null move pruning.
+macro_rules! nmp_reduction_value {
+    () => {
+        3
+    };
+}
+pub(crate) use nmp_reduction_value;


### PR DESCRIPTION
resolves #26 

Implements null move pruning in `negamax` under the following restrictions:
- Must not be in a PV node
- Must not be in check
- Depth must be at least `MIN_NMP_DEPTH` (3)
- Cannot make two null moves in a row
- Board state cannot consist solely of Kings and Pawns

This was a large gainer, and didn't need much tweaking.

Here is the SPRT for avoiding NMP when in PV nodes:
```
Elo   | 6.63 +- 5.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.11 (-2.94, 2.94) [0.00, 10.00]
Games | N: 10854 W: 4056 L: 3849 D: 2949
Penta | [544, 974, 2265, 1019, 625]
```
https://pyronomy.pythonanywhere.com/test/140/

---
SPRT:
```
Elo   | 156.17 +- 41.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 10.00]
Games | N: 242 W: 152 L: 50 D: 40
Penta | [2, 7, 43, 25, 44]
```
https://pyronomy.pythonanywhere.com/test/139/

bench: 38268046