### PR TITLE
feat: reverse futility pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ If you are willing to test the installation and execution of Toad on other opera
     -   [Principal Variation Search](https://www.chessprogramming.org/Principal_Variation_Search).
     -   [Aspiration Windows](https://www.chessprogramming.org/Aspiration_Windows) with [gradual widening](https://www.chessprogramming.org/Aspiration_Windows#Gradual_Widening).
     -   [Null Move Pruning](https://www.chessprogramming.org/Null_Move_Pruning).
+    -   [Reverse Futility Pruning](https://www.chessprogramming.org/Reverse_Futility_Pruning).
     -   Move Ordering:
         -   [MVV-LVA](https://www.chessprogramming.org/MVV-LVA) with relative piece values `K < P < N < B < R < Q`, so `KxR` is ordered before `PxR`.
         -   [Hash moves](https://www.chessprogramming.org/Hash_Move).

--- a/src/score.rs
+++ b/src/score.rs
@@ -44,6 +44,9 @@ impl Score {
     /// Value to subtract from a history score at a given depth.
     pub const HISTORY_OFFSET: Self = Self(tune::history_offset!());
 
+    /// Safety margin when applying reverse futility pruning.
+    pub const RFP_MARGIN: Self = Self(tune::rfp_margin!());
+
     /// Returns `true` if the score is a mate score.
     #[inline(always)]
     pub fn is_mate(&self) -> bool {

--- a/src/search.rs
+++ b/src/search.rs
@@ -856,6 +856,8 @@ impl<'a, const LOG: u8, V: Variant> Search<'a, LOG, V> {
         /****************************************************************************************************
          * Reverse Futility Pruning: https://www.chessprogramming.org/Reverse_Futility_Pruning
          ****************************************************************************************************/
+        // If our static eval is too good (better than beta), we can prune this branch.
+        // Multiplying our margin by depth makes this pruning process less risky for higher depths.
         let rfp_score = game.eval() - Score::RFP_MARGIN * depth as i32;
         if depth <= MAX_RFP_DEPTH && rfp_score >= beta {
             return Some(rfp_score);

--- a/src/search.rs
+++ b/src/search.rs
@@ -856,7 +856,7 @@ impl<'a, const LOG: u8, V: Variant> Search<'a, LOG, V> {
         /****************************************************************************************************
          * Reverse Futility Pruning: https://www.chessprogramming.org/Reverse_Futility_Pruning
          ****************************************************************************************************/
-        let rfp_score = game.eval() - Score::RFP_MARGIN;
+        let rfp_score = game.eval() - Score::RFP_MARGIN * depth as i32;
         if depth <= MAX_RFP_DEPTH && rfp_score >= beta {
             return Some(rfp_score);
         }

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -110,3 +110,19 @@ macro_rules! nmp_reduction_value {
     };
 }
 pub(crate) use nmp_reduction_value;
+
+/// MAximum depth at which to apply reverse futility pruning.
+macro_rules! max_rfp_depth {
+    () => {
+        5
+    };
+}
+pub(crate) use max_rfp_depth;
+
+/// Safety margin when applying reverse futility pruning.
+macro_rules! rfp_margin {
+    () => {
+        75
+    };
+}
+pub(crate) use rfp_margin;


### PR DESCRIPTION
resolves #25 

Implements Reverse Futility Pruning within the `negamax` search. The values for `RFP_MARGIN` and `MAX_RFP_DEPTH` can be accredited to @Ciekce, author of [Stormphrax](https://github.com/Ciekce/Stormphrax), from [this Discord discussion](https://discord.com/channels/719576389245993010/719576389690589244/1307412495140651159).

---
SPRT:
```
Elo   | 72.27 +- 26.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 10.00]
Games | N: 434 W: 203 L: 114 D: 117
Penta | [9, 35, 73, 58, 42]
```
https://pyronomy.pythonanywhere.com/test/145/

bench: 20141032