### PR TITLE
accurate mate scores

### DIFF
--- a/toad/src/score.rs
+++ b/toad/src/score.rs
@@ -101,44 +101,16 @@ impl Score {
         relative_to_side / 2
     }
 
-    /// Normalize the score to the provided ply.
-    ///
-    /// Score will be relative to `ply`.
-    #[inline(always)]
-    pub fn relative(self, ply: Ply) -> Self {
-        if self.is_mate() {
-            // Self(self.0 + ply)
-            if self > Self::DRAW {
-                self + ply
-            } else {
-                self - ply
-            }
-        } else {
-            self
-        }
-    }
-
-    /// De-normalize the score from the provided ply.
-    ///
-    /// Score will be relative to root (0 ply).
-    #[inline(always)]
-    pub fn absolute(self, ply: Ply) -> Self {
-        if self.is_mate() {
-            // Self(self.0 - ply)
-            if self > Self::DRAW {
-                self - ply
-            } else {
-                self + ply
-            }
-        } else {
-            self
-        }
-    }
-
     /// Returns the absolute value of this [`Score`].
     #[inline(always)]
     pub const fn abs(self) -> Self {
         Self(self.0.abs())
+    }
+
+    /// Returns the sign of this [`Score`].
+    #[inline(always)]
+    pub const fn signum(self) -> Self {
+        Self(self.0.signum())
     }
 
     /// "Normalizes" a score so that it can be printed as a float.
@@ -332,19 +304,5 @@ mod tests {
 
         let their_mate = -(Score::MATE - plies);
         assert_eq!(their_mate.plies_to_mate(), plies.plies() as i32);
-
-        // Relative scores
-        let our_relative = our_mate.relative(plies);
-        assert_eq!(our_relative, Score::MATE);
-
-        let their_relative = their_mate.relative(plies);
-        assert_eq!(their_relative, -Score::MATE);
-
-        // Absolute scores
-        let our_absolute = our_relative.absolute(plies);
-        assert_eq!(our_absolute, our_mate);
-
-        let their_absolute = their_relative.absolute(plies);
-        assert_eq!(their_absolute, their_mate);
     }
 }

--- a/toad/src/ttable.rs
+++ b/toad/src/ttable.rs
@@ -91,7 +91,6 @@ impl TTableEntry {
         score: Score,
         bounds: SearchBounds,
         depth: Ply,
-        ply: Ply,
     ) -> Self {
         // Determine what kind of node this is first, *before* score adjustment
         let node_type = NodeType::new(score, bounds);
@@ -100,7 +99,7 @@ impl TTableEntry {
             key,
             bestmove,
             // Adjust the score (if it was mate) to the ply at which we found it
-            score: score.absolute(ply),
+            score: score,
             depth: depth.plies() as u8,
             node_type,
         }
@@ -253,15 +252,13 @@ impl TTable {
         &self,
         key: ZobristKey,
         depth: Ply,
-        ply: Ply,
         bounds: SearchBounds,
     ) -> ProbeResult {
         // if-let chains are set to be stabilized in Rust 2024 (1.85.0): https://rust-lang.github.io/rfcs/2497-if-let-chains.html
         if let Some(entry) = self.get(&key) {
             // Can only cut off if the existing entry came from a greater depth.
             if entry.depth() >= depth {
-                // Adjust mate scores to be relative to current ply
-                let score = entry.score.relative(ply);
+                let score = entry.score;
 
                 // If we can cutoff, do so
                 if entry.node_type == NodeType::Pv


### PR DESCRIPTION
- Removes mate distance correction from TT tables.
- Replaces all mate distance stuff with one simple `if` statement.
- Makes mate distance pruning unnecessary.