### PR TITLE
fix: removed draw detection at ply 1

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -961,8 +961,8 @@ impl<'a, Log: LogLevel, V: Variant> Search<'a, Log, V> {
             /****************************************************************************************************
              * Recursion of the search
              ****************************************************************************************************/
-            // Don't bother searching drawn positions, unless we're in the root node.
-            if Node::ROOT || !self.is_draw(&new) {
+            // Don't bother searching drawn positions.
+            if !self.is_draw(&new) {
                 // Append this position onto our stack, so we can detect repetitions
                 self.prev_positions.push(*new.position());
 
@@ -1179,8 +1179,8 @@ impl<'a, Log: LogLevel, V: Variant> Search<'a, Log, V> {
             /****************************************************************************************************
              * Recursion of the search
              ****************************************************************************************************/
-            // Don't bother searching drawn positions, unless we're in the root node.
-            if Node::ROOT || !self.is_draw(&new) {
+            // Don't bother searching drawn positions.
+            if !self.is_draw(&new) {
                 // Append this position onto our stack, so we can detect repetitions
                 self.prev_positions.push(*new.position());
 


### PR DESCRIPTION
It was pointed out to me that I was skipping draw detection at ply 1, so this PR fixes that.


---
SPRT:
```
Elo   | -1.02 +- 1.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 72870 W: 21759 L: 21972 D: 29139
Penta | [2019, 7934, 16714, 7777, 1991]
```
https://pyronomy.pythonanywhere.com/test/789/

(note: it's for a different branch, but the contents of that branch and this one are equal- minus the annoying merge conflicts)

bench: 8515103